### PR TITLE
Adopt code from py2neo to remove the use of the `id` function in cypher queries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+## MIT License
 
 Copyright (c) 2022 Open Force Field Initiative
 
@@ -19,3 +19,212 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+## Apache 2.0 Licensed Code
+
+This project includes code from py2neo, which is licensed under the Apache License 2.0. The Apache License 2.0 text is included below for reference.
+
+## Apache 2.0 License
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,38 @@
+# NOTICE
+
+This project includes software developed by py2neo (https://github.com/neo4j-contrib/py2neo/tree/master).
+
+## Original NOTICE
+
+    py2neo
+    Copyright (c) "Neo4j"
+    Neo4j Sweden AB [https://neo4j.com]
+    
+    This product includes software developed by
+    Neo4j, Inc. <drivers@neo4j.com>.
+    
+    This product includes software developed by
+    Nigel Small <technige@nige.tech>.
+    
+    This product includes software developed by
+    Simon Harrison <noisyboiler@googlemail.com>.
+    
+    This product includes software developed by
+    Marcel Hellkamp <https://bottlepy.org>.
+
+## Modifications
+
+- alchemiscale/storage/cypher.py
+    - Functions modified from the py2neo.cypher.queries module:
+        - _match_clause
+    - Modifications made:
+        - switched all usage of the id function to elementId
+
+- alchemiscale/storage/subgraph.py
+    - Functions modified form the py2neo.data module:
+         - Subgraph.__db_merge__ (moved to merge_subgraph)
+         - Subgraph.__db_create__ (moved to create_subgraph)
+    - Modifications made:
+        - switched all usage of the id function to elementId
+        - removed the usage of py2neo database connections
+          and replaced them with the official neo4j driver

--- a/NOTICE
+++ b/NOTICE
@@ -29,7 +29,7 @@ This project includes software developed by py2neo (https://github.com/neo4j-con
         - switched all usage of the id function to elementId
 
 - alchemiscale/storage/subgraph.py
-    - Functions modified form the py2neo.data module:
+    - Functions modified from the py2neo.data module:
          - Subgraph.__db_merge__ (moved to merge_subgraph)
          - Subgraph.__db_create__ (moved to create_subgraph)
     - Modifications made:

--- a/alchemiscale/storage/cypher.py
+++ b/alchemiscale/storage/cypher.py
@@ -1,6 +1,18 @@
 from alchemiscale import ScopedKey
 from typing import List, Optional
 
+from py2neo.cypher.queries import (
+    _create_clause,
+    _merge_clause,
+    _on_create_set_properties_clause,
+    _relationship_data,
+    _set_labels_clause,
+    _set_properties_clause,
+    cypher_escape,
+    cypher_join,
+)
+from py2neo.cypher.queries import NodeKey
+
 
 def cypher_list_from_scoped_keys(scoped_keys: List[Optional[ScopedKey]]) -> str:
     """Generate a Cypher list structure from a list of ScopedKeys, ignoring NoneType entries.
@@ -28,3 +40,111 @@ def cypher_list_from_scoped_keys(scoped_keys: List[Optional[ScopedKey]]) -> str:
 
 def cypher_or(items):
     return "|".join(items)
+
+
+# Original code from py2neo, licensed under the Apache License 2.0.
+# Modifications by alchemiscale:
+#   - switched id function to use elementId
+def _match_clause(name, node_key, value, prefix="(", suffix=")"):
+    if node_key is None:
+        # ... add MATCH by id clause
+        return "MATCH %s%s%s WHERE elementId(%s) = %s" % (
+            prefix,
+            name,
+            suffix,
+            name,
+            value,
+        )
+    else:
+        # ... add MATCH by label/property clause
+        nk = NodeKey(node_key)
+        n_pk = len(nk.keys())
+        if n_pk == 0:
+            return "MATCH %s%s%s%s" % (prefix, name, nk.label_string(), suffix)
+        elif n_pk == 1:
+            return "MATCH %s%s%s {%s:%s}%s" % (
+                prefix,
+                name,
+                nk.label_string(),
+                cypher_escape(nk.keys()[0]),
+                value,
+                suffix,
+            )
+        else:
+            return "MATCH %s%s%s {%s}%s" % (
+                prefix,
+                name,
+                nk.label_string(),
+                nk.key_value_string(value, list(range(n_pk))),
+                suffix,
+            )
+
+
+# Original code from py2neo, licensed under the Apache License 2.0.
+def unwind_merge_nodes_query(data, merge_key, labels=None, keys=None, preserve=None):
+    """Generate a parameterised ``UNWIND...MERGE`` query for bulk
+    loading nodes into Neo4j.
+
+    :param data:
+    :param merge_key:
+    :param labels:
+    :param keys:
+    :param preserve:
+        Collection of key names for values that should be protected
+        should the node already exist.
+    :return: (query, parameters) tuple
+    """
+    return cypher_join(
+        "UNWIND $data AS r",
+        _merge_clause("_", merge_key, "r", keys),
+        _on_create_set_properties_clause("r", keys, preserve),
+        _set_properties_clause("r", keys, exclude_keys=preserve),
+        _set_labels_clause(labels),
+        data=list(data),
+    )
+
+
+# Original code from py2neo, licensed under the Apache License 2.0.
+def unwind_merge_relationships_query(
+    data, merge_key, start_node_key=None, end_node_key=None, keys=None, preserve=None
+):
+    """Generate a parameterised ``UNWIND...MERGE`` query for bulk
+    loading relationships into Neo4j.
+
+    :param data:
+    :param merge_key: tuple of (rel_type, key1, key2...)
+    :param start_node_key:
+    :param end_node_key:
+    :param keys:
+    :param preserve:
+        Collection of key names for values that should be protected
+        should the relationship already exist.
+    :return: (query, parameters) tuple
+    """
+    return cypher_join(
+        "UNWIND $data AS r",
+        _match_clause("a", start_node_key, "r[0]"),
+        _match_clause("b", end_node_key, "r[2]"),
+        _merge_clause("_", merge_key, "r[1]", keys, "(a)-[", "]->(b)"),
+        _on_create_set_properties_clause("r[1]", keys, preserve),
+        _set_properties_clause("r[1]", keys, exclude_keys=preserve),
+        data=_relationship_data(data),
+    )
+
+
+# Original code from py2neo, licensed under the Apache License 2.0.
+def unwind_create_nodes_query(data, labels=None, keys=None):
+    """Generate a parameterised ``UNWIND...CREATE`` query for bulk
+    loading nodes into Neo4j.
+
+    :param data:
+    :param labels:
+    :param keys:
+    :return: (query, parameters) tuple
+    """
+    return cypher_join(
+        "UNWIND $data AS r",
+        _create_clause("_", (tuple(labels or ()),)),
+        _set_properties_clause("r", keys),
+        data=list(data),
+    )

--- a/alchemiscale/storage/cypher.py
+++ b/alchemiscale/storage/cypher.py
@@ -85,14 +85,19 @@ def unwind_merge_nodes_query(data, merge_key, labels=None, keys=None, preserve=N
     """Generate a parameterised ``UNWIND...MERGE`` query for bulk
     loading nodes into Neo4j.
 
-    :param data:
-    :param merge_key:
-    :param labels:
-    :param keys:
-    :param preserve:
+    Parameters
+    ----------
+    data
+    merge_key
+    labels
+    keys
+    preserve
         Collection of key names for values that should be protected
         should the node already exist.
-    :return: (query, parameters) tuple
+
+    Returns
+    -------
+    (query, parameters) tuple
     """
     return cypher_join(
         "UNWIND $data AS r",
@@ -111,15 +116,20 @@ def unwind_merge_relationships_query(
     """Generate a parameterised ``UNWIND...MERGE`` query for bulk
     loading relationships into Neo4j.
 
-    :param data:
-    :param merge_key: tuple of (rel_type, key1, key2...)
-    :param start_node_key:
-    :param end_node_key:
-    :param keys:
-    :param preserve:
+    Parameters
+    ----------
+    data
+    merge_key : tuple[str, ...]
+    start_node_key
+    end_node_key
+    keys
+    preserve
         Collection of key names for values that should be protected
         should the relationship already exist.
-    :return: (query, parameters) tuple
+
+    Returns
+    -------
+    (query, parameters) : tuple
     """
     return cypher_join(
         "UNWIND $data AS r",
@@ -137,10 +147,15 @@ def unwind_create_nodes_query(data, labels=None, keys=None):
     """Generate a parameterised ``UNWIND...CREATE`` query for bulk
     loading nodes into Neo4j.
 
-    :param data:
-    :param labels:
-    :param keys:
-    :return: (query, parameters) tuple
+    Parameters
+    ----------
+    data
+    labels
+    keys
+
+    Returns
+    -------
+    (query, parameters) : tuple
     """
     return cypher_join(
         "UNWIND $data AS r",


### PR DESCRIPTION
The unmaintained `py2neo` package generated queries contain functions that are deprecated. In order to avoid the a torrent of deprecation warnings in the near future and broken functionality on the next major release of neo4j, we are adopting the query generators from within py2neo and modifying them to satisfy our needs in alchemiscale.

In compliance with the Apache v2.0 license, we are providing a copy of the Apache v2.0 license with our distribution and providing a NOTICE containing a log of our modifications.