### PR TITLE
Replace passlib with bcrypt

### DIFF
--- a/alchemiscale/security/auth.py
+++ b/alchemiscale/security/auth.py
@@ -24,7 +24,7 @@ from .models import CredentialedEntity, Token, TokenData
 # increasing amounts of time or memory to validate;
 # this is deliberately higher than any reasonable key length
 # this is the same max size that `passlib` defaults to
-MAX_SECRET_SIZE = 72
+MAX_SECRET_SIZE = 4096
 
 
 class BcryptPasswordHandler(object):

--- a/alchemiscale/security/auth.py
+++ b/alchemiscale/security/auth.py
@@ -46,7 +46,7 @@ class BcryptPasswordHandler(object):
         hashed = base64.b64encode(hashlib.sha256(key.encode("utf-8")).digest())
         hashed_salted = bcrypt.hashpw(hashed, salt)
 
-        return hashed_salted
+        return hashed_salted.decode('utf-8')
 
     def verify(self, key: str, hashed_salted: str) -> bool:
         validate_secret(key)

--- a/alchemiscale/security/auth.py
+++ b/alchemiscale/security/auth.py
@@ -24,7 +24,7 @@ from .models import CredentialedEntity, Token, TokenData
 # increasing amounts of time or memory to validate;
 # this is deliberately higher than any reasonable key length
 # this is the same max size that `passlib` defaults to
-MAX_SECRET_SIZE = 4096
+MAX_SECRET_SIZE = 72
 
 
 class BcryptPasswordHandler(object):

--- a/alchemiscale/security/auth.py
+++ b/alchemiscale/security/auth.py
@@ -38,33 +38,14 @@ class BcryptPasswordHandler(object):
 
         # generate a salt unique to this key
         salt = bcrypt.gensalt(rounds=self.rounds, prefix=self.ident.encode("ascii"))
-
-        # bcrypt can handle up to 72 characters
-        # to go beyond this, we first perform sha256 hashing,
-        # then base64 encode to avoid NULL byte problems
-        # details: https://github.com/pyca/bcrypt/?tab=readme-ov-file#maximum-password-length
-
-        # to reproduce `passlib` behavior, we only perform sha256 hashing if
-        # key is longer than the sha256 default block size of 64
-        key_ = key.encode("utf-8")
-        if len(key_) > 64:
-            key_ = base64.b64encode(hashlib.sha256(key_).digest())
-
-        hashed_salted = bcrypt.hashpw(key_, salt)
+        hashed_salted = bcrypt.hashpw(key.encode("utf-8"), salt)
 
         return hashed_salted.decode("utf-8")
 
     def verify(self, key: str, hashed_salted: str) -> bool:
         validate_secret(key)
 
-        # see note above on why we perform sha256 hashing first
-        # to reproduce `passlib` behavior, we only perform sha256 hashing if
-        # key is longer than the sha256 default block size of 64
-        key_ = key.encode("utf-8")
-        if len(key_) > 64:
-            key_ = base64.b64encode(hashlib.sha256(key_).digest())
-
-        return bcrypt.checkpw(key_, hashed_salted.encode("utf-8"))
+        return bcrypt.checkpw(key.encode("utf-8"), hashed_salted.encode("utf-8"))
 
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")

--- a/alchemiscale/security/auth.py
+++ b/alchemiscale/security/auth.py
@@ -46,7 +46,7 @@ class BcryptPasswordHandler(object):
         hashed = base64.b64encode(hashlib.sha256(key.encode("utf-8")).digest())
         hashed_salted = bcrypt.hashpw(hashed, salt)
 
-        return hashed_salted.decode('utf-8')
+        return hashed_salted.decode("utf-8")
 
     def verify(self, key: str, hashed_salted: str) -> bool:
         validate_secret(key)

--- a/alchemiscale/security/auth.py
+++ b/alchemiscale/security/auth.py
@@ -18,7 +18,13 @@ from pydantic import BaseModel
 
 from .models import CredentialedEntity, Token, TokenData
 
-MAX_PASSWORD_SIZE = 4096
+
+# we set a max size to avoid denial-of-service attacks
+# since an extremely large secret attempted by an attacker can take
+# increasing amounts of time or memory to validate;
+# this is deliberately higher than any reasonable key length
+# this is the same max size that `passlib` defaults to
+MAX_SECRET_SIZE = 4096
 
 
 class BcryptPasswordHandler(object):
@@ -59,9 +65,9 @@ def validate_secret(secret):
     """ensure secret has correct type & size"""
     if not isinstance(secret, (str, bytes)):
         raise TypeError("secret must be a string or bytes")
-    if len(secret) > MAX_PASSWORD_SIZE:
+    if len(secret) > MAX_SECRET_SIZE:
         raise ValueError(
-            f"secret is too long, maximum length is {MAX_PASSWORD_SIZE} characters"
+            f"secret is too long, maximum length is {MAX_SECRET_SIZE} characters"
         )
 
 

--- a/alchemiscale/tests/unit/test_security.py
+++ b/alchemiscale/tests/unit/test_security.py
@@ -30,3 +30,10 @@ def test_token_data(secret_key):
     token_data = auth.get_token_data(token=token, secret_key=secret_key)
 
     assert token_data.scopes == ["*-*-*"]
+
+
+def test_bcrypt_password_handler():
+    handler = auth.BcryptPasswordHandler()
+    hash_ = handler.hash("test")
+    assert handler.verify("test", hash_)
+    assert not handler.verify("deadbeef", hash_)

--- a/alchemiscale/tests/unit/test_security.py
+++ b/alchemiscale/tests/unit/test_security.py
@@ -37,3 +37,16 @@ def test_bcrypt_password_handler():
     hash_ = handler.hash("test")
     assert handler.verify("test", hash_)
     assert not handler.verify("deadbeef", hash_)
+
+
+def test_bcrypt_against_passlib():
+    """Test the our bcrypt handler has the same behavior as passlib did"""
+
+    # pre-generated hash from
+    # `passlib.context.CryptContext(schemes=["bcrypt"], deprecated="auto").hash()`
+    test_password = "the quick brown fox jumps over the lazy dog"
+    test_hash = "$2b$12$QZTnjdx/sJS7jnEnCqhM3uS8mZ4mhLV5dDfM7ZBUT6LwDiNZ2p7S."
+
+    # test that we get the same thing back from our bcrypt handler
+    handler = auth.BcryptPasswordHandler()
+    assert handler.verify(test_password, test_hash)

--- a/alchemiscale/tests/unit/test_security.py
+++ b/alchemiscale/tests/unit/test_security.py
@@ -50,3 +50,16 @@ def test_bcrypt_against_passlib():
     # test that we get the same thing back from our bcrypt handler
     handler = auth.BcryptPasswordHandler()
     assert handler.verify(test_password, test_hash)
+
+
+def test_bcrypt_against_passlib_long():
+    """Test the our bcrypt handler has the same behavior as passlib did for passwords longer than 72 characters, in which bcrypt truncates"""
+
+    # pre-generated hash from
+    # `passlib.context.CryptContext(schemes=["bcrypt"], deprecated="auto").hash()`
+    test_password = "this password is so long, it's longer than 72 characters; this should get truncated by bcrypt, so we can ensure we get the same verification behavior as passlib gives"
+    test_hash = "$2b$12$DQd5IPjlc8z4FZjBIdaquOlVc9whAqnkpZRsnuUUWvfHvwWy.dZ16"
+
+    # test that we get the same thing back from our bcrypt handler
+    handler = auth.BcryptPasswordHandler()
+    assert handler.verify(test_password, test_hash)

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -29,7 +29,6 @@ dependencies:
   - uvicorn
   - gunicorn
   - python-jose
-  - passlib
   - bcrypt
   - python-multipart
   - starlette

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -17,7 +17,7 @@ dependencies:
   - monotonic
   - docker-py    # for grolt
 
-  # user client printing 
+  # user client printing
   - rich
 
   ## object store
@@ -28,7 +28,6 @@ dependencies:
   - uvicorn
   - gunicorn
   - python-jose
-  - passlib
   - bcrypt
   - python-multipart
   - starlette

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,6 @@ autodoc_mock_imports = [
     "jose",
     "networkx",
     "numpy",
-    "passlib",
     "py2neo",
     "pydantic",
     "starlette",


### PR DESCRIPTION
## Summary:

This pull request replaces the usage of the `passlib` library with `bcrypt` for password hashing and verification. 

## Changes:

- remove `passlib` from conda environments and auth.py
- Added `BcryptPasswordHandler` with same defaults as in `passlib.context.CryptContext`

See #304 for motivation