### PR TITLE
Addressing failures in CI

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -32,7 +32,7 @@ jobs:
           - "3.12"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: mamba-org/setup-micromamba@v1
         with:

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -31,7 +31,7 @@ dependencies:
   - python-jose
   - passlib
   - bcrypt
-  - python-multipart
+  - python-multipart=0.0.12    # temporarily pinned due to broken 0.14 release on conda-forge
   - starlette
   - httpx
   - cryptography

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -30,7 +30,7 @@ dependencies:
   - python-jose
   - passlib
   - bcrypt
-  - python-multipart=0.0.12
+  - python-multipart=0.0.12    # temporarily pinned due to broken 0.14 release on conda-forge
   - starlette
   - httpx
   - cryptography

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -30,7 +30,7 @@ dependencies:
   - python-jose
   - passlib
   - bcrypt
-  - python-multipart
+  - python-multipart=0.0.12
   - starlette
   - httpx
   - cryptography


### PR DESCRIPTION
It's not exactly clear what the main cause is, but CI is failing on [main](https://github.com/OpenFreeEnergy/alchemiscale/actions/runs/11196799670/job/32072143760) (previously passing) and other [PRs](https://github.com/OpenFreeEnergy/alchemiscale/actions/runs/11507970786/job/32035228211).

The main issue seems to be that a `fastapi` dependency, `python-multipart`, isn't installing correctly.