### PR TITLE
Use python < 3.13 for building docs

### DIFF
--- a/devtools/conda-envs/docs.yml
+++ b/devtools/conda-envs/docs.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 
 dependencies:
+  - python<3.13
   - sphinx>=5.0,<6
   - sphinx_rtd_theme
   - async-lru


### PR DESCRIPTION
Python v3.13 removed imghdr, which is used by the versions sphinx we use for building our docs. Since we don't officially support 3.13 yet, we can get the docs working by adding this constraint. A better option would be to use newer versions of Sphinx, but that can be done in a different commit.

See https://github.com/sphinx-doc/sphinx/issues/10440