### PR TITLE
[WIP] Add use of zstd compression on compute services

### DIFF
--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -15,6 +15,7 @@ dependencies:
   - httpx
   - pydantic<2.0
   - async-lru
+  - zstandard
 
   ## user client
   - rich

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -15,6 +15,7 @@ dependencies:
   - httpx
   - pydantic<2.0
   - async-lru
+  - zstandard
 
   # openmm protocols
   - feflow=0.1.0

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -10,6 +10,7 @@ dependencies:
   # alchemiscale dependencies
   - gufe=1.1.0
   - openfe=1.2.0
+  - zstandard
 
   - requests
   - click

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -11,6 +11,7 @@ dependencies:
   - openfe>=1.2.0
   - pydantic<2.0
   - async-lru
+  - zstandard
 
   ## state store
   - neo4j-python-driver


### PR DESCRIPTION
This PR closes #220. It modifies the behavior of set_task_results in the compute client and api to use compressed keyed chain representations of ProtocolDAGResults instead of simple JSON serialization as the intermediate format.