### PR TITLE
`SynchronousComputeService` now properly claims tasks with protocols filter

### DIFF
--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -157,18 +157,25 @@ class SynchronousComputeService:
             self.beat()
             time.sleep(self.heartbeat_interval)
 
-    def claim_tasks(self) -> List[Optional[ScopedKey]]:
+    def claim_tasks(self, count=1) -> List[Optional[ScopedKey]]:
         """Get a Task to execute from compute API.
 
         Returns `None` if no Task was available matching service configuration.
 
+        Parameters
+        ----------
+        count
+            The maximum number of Tasks to claim.
         """
-        return self.client.claim_tasks(
+
+        tasks = self.client.claim_tasks(
             scopes=self.scopes,
             compute_service_id=self.compute_service_id,
-            count=self.claim_limit,
+            count=count,
             protocols=self.settings.protocols,
-        )
+            )
+
+        return tasks
 
     def task_to_protocoldag(
         self, task: ScopedKey
@@ -293,7 +300,7 @@ class SynchronousComputeService:
 
         # claim tasks from the compute API
         self.logger.info("Claiming tasks")
-        tasks: List[ScopedKey] = self.claim_tasks()
+        tasks: List[ScopedKey] = self.claim_tasks(count=self.claim_limit)
         self.logger.info("Claimed %d tasks", len([t for t in tasks if t is not None]))
 
         # if no tasks claimed, sleep

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -157,6 +157,19 @@ class SynchronousComputeService:
             self.beat()
             time.sleep(self.heartbeat_interval)
 
+    def claim_tasks(self) -> List[Optional[ScopedKey]]:
+        """Get a Task to execute from compute API.
+
+        Returns `None` if no Task was available matching service configuration.
+
+        """
+        return self.client.claim_tasks(
+            scopes=self.scopes,
+            compute_service_id=self.compute_service_id,
+            count=self.claim_limit,
+            protocols=self.settings.protocols,
+        )
+
     def task_to_protocoldag(
         self, task: ScopedKey
     ) -> Tuple[ProtocolDAG, Transformation, Optional[ProtocolDAGResult]]:
@@ -280,12 +293,7 @@ class SynchronousComputeService:
 
         # claim tasks from the compute API
         self.logger.info("Claiming tasks")
-        tasks: List[ScopedKey] = self.client.claim_tasks(
-            scopes=self.scopes,
-            compute_service_id=self.compute_service_id,
-            count=self.claim_limit,
-            protocols=self.settings.protocols,
-        )
+        tasks: List[ScopedKey] = self.claim_tasks()
         self.logger.info("Claimed %d tasks", len([t for t in tasks if t is not None]))
 
         # if no tasks claimed, sleep

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -173,7 +173,7 @@ class SynchronousComputeService:
             compute_service_id=self.compute_service_id,
             count=count,
             protocols=self.settings.protocols,
-            )
+        )
 
         return tasks
 


### PR DESCRIPTION
We weren't actually using the `protocols` setting for the `SynchronousComputeService`, so `Task` claims weren't being filtered if this was set to anything but `None`.
