### PR TITLE
Updated `gufe` and `openfe` versions in conda envs, added `cuda-version > 12` to avoid pulling `cudatoolkit`

### DIFF
--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -9,7 +9,7 @@ dependencies:
 
   # alchemiscale dependencies
   - gufe=1.2.0
-  - openfe=1.3.0
+  - openfe=1.2.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -1,15 +1,15 @@
 name: alchemiscale-client
 channels:
-  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 
 dependencies:
   - pip
   - python=3.12
+  - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe=1.1.0
-  - openfe=1.2.0
+  - gufe=1.2.0
+  - openfe=1.3.0
   - requests
   - click
   - httpx
@@ -31,4 +31,4 @@ dependencies:
   - openff-units=0.2.2
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale.git@v0.5.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale.git@main

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -5,11 +5,11 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cudatoolkit =11.8
+  - cuda-version >=12
   
   # alchemiscale dependencies
-  - gufe=1.1.0
-  - openfe=1.2.0
+  - gufe=1.2.0
+  - openfe=1.3.0
   - requests
   - click
   - httpx
@@ -27,4 +27,4 @@ dependencies:
   - openff-units=0.2.2
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale.git@v0.5.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale.git@main

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -9,7 +9,7 @@ dependencies:
   
   # alchemiscale dependencies
   - gufe=1.2.0
-  - openfe=1.3.0
+  - openfe=1.2.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -9,7 +9,7 @@ dependencies:
 
   # alchemiscale dependencies
   - gufe=1.2.0
-  - openfe=1.3.0
+  - openfe=1.2.0
   - zstandard
 
   - requests

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -1,15 +1,15 @@
 name: alchemiscale-server
 channels:
-  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 
 dependencies:
   - pip
   - python=3.12
+  - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe=1.1.0
-  - openfe=1.2.0
+  - gufe=1.2.0
+  - openfe=1.3.0
   - zstandard
 
   - requests
@@ -48,4 +48,4 @@ dependencies:
   - curl         # used in healthchecks for API services
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale.git@v0.5.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale.git@main

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -8,7 +8,7 @@ dependencies:
 
   # alchemiscale dependencies
   - gufe=1.2.0
-  - openfe=1.3.0
+  - openfe=1.2.0
   - pydantic >2
   - pydantic-settings
   - async-lru

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -1,14 +1,14 @@
 name: alchemiscale-test
 channels:
-  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 
 dependencies:
   - pip
+  - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe>=1.1.0
-  - openfe>=1.2.0
+  - gufe=1.2.0
+  - openfe=1.3.0
   - pydantic >2
   - pydantic-settings
   - async-lru


### PR DESCRIPTION
Attempting to see if this decreases image sizes; this would also be our approach for building 0.6.0 images.

Addresses #266.