### PR TITLE
Pin libsqlite to <3.49

### DIFF
--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -13,6 +13,7 @@ dependencies:
   - pydantic-settings
   - async-lru
   - diskcache
+  - libsqlite<3.49  # newer versions cause diskcache to fail
   - zstandard
 
   ## state store


### PR DESCRIPTION
Newer versions cause diskcache to fail.