### PR TITLE
Fix broken codepath in compute API for resolving task restarts for failed ProtocolDAGResults

### DIFF
--- a/alchemiscale/compute/api.py
+++ b/alchemiscale/compute/api.py
@@ -365,7 +365,7 @@ async def set_task_result(
             pdr.protocol_unit_failures, result_sk
         )
         n4js.set_task_error(tasks=[task_sk])
-        n4js.resolve_task_restarts(tasks=[task_sk])
+        n4js.resolve_task_restarts(task_scoped_keys=[task_sk])
 
     return result_sk
 

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -2592,8 +2592,9 @@ class Neo4jStore(AlchemiscaleStateStore):
 
         Returns
         -------
-        Dict[ScopedKey,TaskStatusEnum]
-            A dictionary of Tasks and their statuses.
+            A list of the Task statuses requested; `None` is given for any
+            Tasks that do not exist.
+
         """
         statuses = []
         with self.transaction() as tx:

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -613,7 +613,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         network: AlchemicalNetwork,
         scope: Scope,
         state: Union[NetworkStateEnum, str] = NetworkStateEnum.active,
-    ):
+    ) -> Tuple[ScopedKey, ScopedKey, ScopedKey]:
         """Create all nodes and relationships needed for an AlchemicalNetwork
         represented in an alchemiscale state store.
 

--- a/alchemiscale/tests/integration/compute/client/test_compute_client.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_client.py
@@ -430,7 +430,9 @@ class TestComputeClient:
         tf_sk = ScopedKey(gufe_key=transformation_failure.key, **scope_test.dict())
 
         # add a network with a transformation that will always fail
-        an_sk, taskhub_sk, _ = n4js_preloaded.assemble_network(network_tyk2_failure, scope_test)
+        an_sk, taskhub_sk, _ = n4js_preloaded.assemble_network(
+            network_tyk2_failure, scope_test
+        )
 
         # create and action a task for the failing transformation
         task_sks = n4js_preloaded.create_tasks([tf_sk])
@@ -451,4 +453,8 @@ class TestComputeClient:
         assert extends_protocoldagresult is None
 
         # push a failed result for the task
-        pdr_sk = compute_client.set_task_result(task_sks[0], protocoldagresults_failure[0])
+        pdr_sk = compute_client.set_task_result(
+            task_sks[0], protocoldagresults_failure[0]
+        )
+
+        assert n4js_preloaded.get_task_status(task_sks)[0] == TaskStatusEnum.error

--- a/alchemiscale/tests/integration/compute/client/test_compute_client.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_client.py
@@ -412,3 +412,43 @@ class TestComputeClient:
 
         assert transformation2 == transformation_
         assert extends_protocoldagresult2 == protocoldagresults[0]
+
+    def test_set_task_result_failure(
+        self,
+        scope_test,
+        n4js_preloaded,
+        compute_client: client.AlchemiscaleComputeClient,
+        compute_service_id,
+        network_tyk2_failure,
+        transformation_failure,
+        protocoldagresults_failure,
+        uvicorn_server,
+    ):
+        # register compute service id
+        compute_client.register(compute_service_id)
+
+        tf_sk = ScopedKey(gufe_key=transformation_failure.key, **scope_test.dict())
+
+        # add a network with a transformation that will always fail
+        an_sk, taskhub_sk, _ = n4js_preloaded.assemble_network(network_tyk2_failure, scope_test)
+
+        # create and action a task for the failing transformation
+        task_sks = n4js_preloaded.create_tasks([tf_sk])
+        n4js_preloaded.action_tasks(task_sks, taskhub_sk)
+
+        # claim the task
+        task_sks = compute_client.claim_taskhub_tasks(
+            taskhub_sk, compute_service_id=compute_service_id
+        )
+
+        # get the transformation corresponding to this task
+        (
+            transformation_,
+            extends_protocoldagresult,
+        ) = compute_client.retrieve_task_transformation(task_sks[0])
+
+        assert transformation_ == transformation_failure
+        assert extends_protocoldagresult is None
+
+        # push a failed result for the task
+        pdr_sk = compute_client.set_task_result(task_sks[0], protocoldagresults_failure[0])

--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -31,5 +31,8 @@ dependencies:
   - openmmforcefields>=0.14.1
   - openff-units=0.2.2
 
+  ## pins due to breaking changes
+  - openff-interchange =0.4.1    # https://github.com/openmm/openmmforcefields/issues/365
+
   - pip:
     - git+https://github.com/OpenFreeEnergy/alchemiscale.git@v0.6.0

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -26,5 +26,8 @@ dependencies:
   - openmmforcefields>=0.14.1
   - openff-units=0.2.2
 
+  ## pins due to breaking changes
+  - openff-interchange =0.4.1    # https://github.com/openmm/openmmforcefields/issues/365
+
   - pip:
     - git+https://github.com/OpenFreeEnergy/alchemiscale.git@v0.6.0

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -44,6 +44,9 @@ dependencies:
   - openmmforcefields>=0.14.1
   - openff-units=0.2.2
 
+  ## pins due to breaking changes
+  - openff-interchange =0.4.1    # https://github.com/openmm/openmmforcefields/issues/365
+
   # deployment
   - curl         # used in healthchecks for API services
 

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -56,6 +56,9 @@ dependencies:
   - openmmforcefields>=0.14.1
   - openff-units=0.2.2
 
+  ## pins due to breaking changes
+  - openff-interchange =0.4.1    # https://github.com/openmm/openmmforcefields/issues/365
+
   - pip:
     - git+https://github.com/datryllic/grolt # neo4j test server deployment
     - git+https://github.com/OpenFreeEnergy/openfe-benchmarks


### PR DESCRIPTION
Also adds a test for the above.


## Checklist
* [ ] Added a ``news`` entry
<!-- see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command) -->

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
