### PR TITLE
Doc fixes from work on `alchemiscale-fah`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "mambaforge-4.10"
 

--- a/devtools/conda-envs/docs.yml
+++ b/devtools/conda-envs/docs.yml
@@ -5,8 +5,7 @@ channels:
 dependencies:
   - python<3.13
   - sphinx>=5.0,<6
-  - sphinx_rtd_theme
-  - async-lru
+  - sphinx-rtd-theme
   - myst-nb
   - myst-parser>=0.14
   - docutils

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_mock_imports = [
     "async_lru",
+    "diskcache",
+    "zstandard",
     "boto3",
     "click",
     "fastapi",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,8 +36,7 @@ and the :ref:`developer-guide` for details on how the components of this archite
 
 
 .. note::
-   This software is pre-alpha and under active development. It is not yet ready
-   for production use and the API is liable to change rapidly at any time. 
+   This software is in beta and under active development. It is used for production purposes by several early-adopters, but its API is still rapidly evolving.
 
 .. _Folding@Home: https://foldingathome.org
 .. _Open Molecular Software Foundation: https://omsf.io


### PR DESCRIPTION
The API docs are currently broken on readthedocs, and I think this is due to us not having mocks listed for new dependencies in our docs `conf.py`.

Also updated a few other bits while I was at it.
