### PR TITLE
Added ability to set cache location, size, or disable entirely for compute services

### DIFF
--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -78,9 +78,12 @@ class SynchronousComputeService:
         self.claim_limit = self.settings.claim_limit
 
         self.client = AlchemiscaleComputeClient(
-            self.settings.api_url,
-            self.settings.identifier,
-            self.settings.key,
+            api_url=self.settings.api_url,
+            identifier=self.settings.identifier,
+            key=self.settings.key,
+            cache_directory=self.settings.client_cache_directory,
+            cache_size_limit=self.settings.client_cache_size_limit,
+            use_local_cache=self.settings.client_use_local_cache,
             max_retries=self.settings.client_max_retries,
             retry_base_seconds=self.settings.client_retry_base_seconds,
             retry_max_seconds=self.settings.client_retry_max_seconds,

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -81,11 +81,10 @@ class ComputeServiceSettings(BaseModel):
     )
     client_cache_size_limit: int = Field(
         1073741824,
-        description="Maximum size of the client cache in bytes. Default 1 GiB."
+        description="Maximum size of the client cache in bytes. Default 1 GiB.",
     )
     client_use_local_cache: bool = Field(
-        False,
-        description="Whether or not to use the local cache on disk."
+        False, description="Whether or not to use the local cache on disk."
     )
     client_max_retries: int = Field(
         5,
@@ -104,7 +103,8 @@ class ComputeServiceSettings(BaseModel):
         60.0,
         description=(
             "Maximum number of seconds to sleep between retries; "
-            "avoids runaway exponential backoff while allowing for many retries."),
+            "avoids runaway exponential backoff while allowing for many retries."
+        ),
     )
     client_verify: bool = Field(
         True,

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -70,6 +70,23 @@ class ComputeServiceSettings(BaseModel):
         None,
         description="Path to file for logging output; if not set, logging will only go to STDOUT.",
     )
+    client_cache_directory: Path | str | None = Field(
+        None,
+        description=(
+            "Location of the cache directory as either a `pathlib.Path` or `str`. "
+            "If ``None`` is provided then the directory will be determined via "
+            "the ``XDG_CACHE_HOME`` environment variable or default to "
+            "``${HOME}/.cache/alchemiscale``. Default ``None``."
+        ),
+    )
+    client_cache_size_limit: int = Field(
+        1073741824,
+        description="Maximum size of the client cache in bytes. Default 1 GiB."
+    )
+    client_use_local_cache: bool = Field(
+        False,
+        description="Whether or not to use the local cache on disk."
+    )
     client_max_retries: int = Field(
         5,
         description=(
@@ -85,7 +102,9 @@ class ComputeServiceSettings(BaseModel):
     )
     client_retry_max_seconds: float = Field(
         60.0,
-        description="Maximum number of seconds to sleep between retries; avoids runaway exponential backoff while allowing for many retries.",
+        description=(
+            "Maximum number of seconds to sleep between retries; "
+            "avoids runaway exponential backoff while allowing for many retries."),
     )
     client_verify: bool = Field(
         True,

--- a/devtools/configs/synchronous-compute-settings.yaml
+++ b/devtools/configs/synchronous-compute-settings.yaml
@@ -58,6 +58,18 @@ init:
   # STDOUT.
   logfile: null
 
+  # Location of the cache directory as either a `pathlib.Path` or `str`.
+  # If ``None`` is provided then the directory will be determined via
+  # the ``XDG_CACHE_HOME`` environment variable or default to
+  # ``${HOME}/.cache/alchemiscale``. Default ``None``.
+  client_cache_directory: null
+
+  # Maximum size of the client cache in bytes. Default 1 GiB.
+  client_cache_size_limit: 1073741824
+
+  # Whether or not to use the local cache on disk.
+  client_use_local_cache: false
+
   # Maximum number of times to retry a request. In the case the API service is
   # unresponsive an expoenential backoff is applied with retries until this
   # number is reached. If set to -1, retries will continue indefinitely until


### PR DESCRIPTION
Closes #385.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
