### PR TITLE
Add CHANGELOG via rever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 
 # vim
 *.swp
+
+# rever
+rever/

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,0 +1,5 @@
+===============
+CHANGELOG
+===============
+
+.. current developments

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ and the :ref:`developer-guide` for details on how the components of this archite
    ./operations
    ./development
    ./api
+   CHANGELOG
 
 
 Indices and tables

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/rever.xsh
+++ b/rever.xsh
@@ -1,0 +1,7 @@
+$PROJECT = $GITHUB_REPO = 'alchemiscale'
+$GITHUB_ORG = 'OpenFreeEnergy'
+
+$ACTIVITIES = ['changelog']
+
+$CHANGELOG_FILENAME = 'docs/CHANGELOG.rst'
+$CHANGELOG_TEMPLATE = 'TEMPLATE.rst'


### PR DESCRIPTION
Since we manage a human-readable CHANGELOG in `gufe` via `rever` and it works pretty well, I'm proposing we adopt the practice here.
