### PR TITLE
Returned elements of `get_transformation_chemicalsystems` ordered by `ChemicalSystem` state

### DIFF
--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -478,7 +478,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_transformation_chemicalsystems(
         self, transformation: ScopedKey
     ) -> list[ScopedKey]:
-        """List of ``ScopedKey`` objects for the ``ChemicalSystem`` tokenizables associated with the given ``Transformation`` or ``NonTransformation``.
+        """List of ``ChemicalSystem`` ``ScopedKey`` objects associated with the given ``Transformation`` or ``NonTransformation``.
 
         This method returns a list of ``ChemicalSystem`` ``ScopedKey`` objects ordered by the state names, i.e. "stateA"
         and "stateB". If the ``ScopedKey`` of a ``NonTransformation`` was provided, then the list will have only one

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -478,18 +478,16 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_transformation_chemicalsystems(
         self, transformation: ScopedKey
     ) -> list[ScopedKey]:
-        """List ScopedKeys for the ChemicalSystems associated with the given Transformation.
+        """List of ``ScopedKey`` objects for the ``ChemicalSystem`` tokenizables associated with the given ``Transformation`` or ``NonTransformation``.
+
+        This method returns a list of ``ChemicalSystem`` ``ScopedKey`` objects ordered by the state names, i.e. "stateA"
+        and "stateB". If the ``ScopedKey`` of a ``NonTransformation`` was provided, then the list will have only one
+        element: the ``ScopedKey`` of the "system" ``ChemicalSystem``.
 
         Parameters
         ----------
         transformation
-            The ScopedKey of a Transformation or NonTransformation.
-
-        Returns
-        -------
-        A list of ChemicalSystem ScopedKey objects ordered by the state names, i.e. "stateA" and "stateB". If the
-        ScopedKey of a NonTransformation was provided, then the list will have only one element: the ScopedKey of the
-        "system" ChemicalSystem.
+            The ``ScopedKey`` of a ``Transformation`` or ``NonTransformation``.
         """
         return self._query_resource(
             f"/transformations/{transformation}/chemicalsystems"

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -478,7 +478,19 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_transformation_chemicalsystems(
         self, transformation: ScopedKey
     ) -> list[ScopedKey]:
-        """List ScopedKeys for the ChemicalSystems associated with the given Transformation."""
+        """List ScopedKeys for the ChemicalSystems associated with the given Transformation.
+
+        Parameters
+        ----------
+        transformation
+            The ScopedKey of a Transformation or NonTransformation.
+
+        Returns
+        -------
+        A list of ChemicalSystem ScopedKey objects ordered by the state names, i.e. "stateA" and "stateB". If the
+        ScopedKey of a NonTransformation was provided, then the list will have only one element: the ScopedKey of the
+        "system" ChemicalSystem.
+        """
         return self._query_resource(
             f"/transformations/{transformation}/chemicalsystems"
         )

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -973,8 +973,9 @@ class Neo4jStore(AlchemiscaleStateStore):
     ) -> list[ScopedKey]:
         """List ScopedKeys for the ChemicalSystems associated with the given Transformation."""
         q = """
-        MATCH (:Transformation|NonTransformation {_scoped_key: $transformation})-[:DEPENDS_ON]->(cs:ChemicalSystem)
+        MATCH (:Transformation|NonTransformation {_scoped_key: $transformation})-[deps_on:DEPENDS_ON]->(cs:ChemicalSystem)
         WITH cs._scoped_key as sk
+        ORDER BY deps_on.attribute
         RETURN sk
         """
         sks = []

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -590,12 +590,12 @@ class TestClient:
         tf_sk = user_client.get_scoped_key(_transformation, scope_test)
         cs_sks = user_client.get_transformation_chemicalsystems(tf_sk)
 
-        if transformation_class_name is "Transformation":
+        if transformation_class_name == "Transformation":
             assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
                 _transformation.stateA.key,
                 _transformation.stateB.key,
             ]
-        elif transformation_class_name is "NonTransformation":
+        elif transformation_class_name == "NonTransformation":
             assert len(cs_sks) == 1
             assert cs_sks[0].gufe_key == _transformation.system.key
 

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -577,11 +577,10 @@ class TestClient:
         tf_sk = user_client.get_scoped_key(transformation, scope_test)
         cs_sks = user_client.get_transformation_chemicalsystems(tf_sk)
 
-        assert len(cs_sks) == 2
-        assert {cs_sk.gufe_key for cs_sk in cs_sks} == {
+        assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
             transformation.stateA.key,
             transformation.stateB.key,
-        }
+        ]
 
     def test_get_chemicalsystem_transformations(
         self,

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -567,20 +567,37 @@ class TestClient:
         for an_sk in an_sks:
             assert cs_sk in user_client.get_network_chemicalsystems(an_sk)
 
+    @pytest.mark.parametrize(
+        "transformation_class_name", ["Transformation", "NonTransformation"]
+    )
     def test_get_transformation_chemicalsystems(
         self,
         scope_test,
         n4js_preloaded,
         transformation,
+        nontransformation,
         user_client: client.AlchemiscaleClient,
+        transformation_class_name,
     ):
-        tf_sk = user_client.get_scoped_key(transformation, scope_test)
+        match transformation_class_name:
+            case "Transformation":
+                _transformation = transformation
+            case "NonTransformation":
+                _transformation = nontransformation
+            case _:
+                raise ValueError('Expected "Transformation" or "NonTransformation"')
+
+        tf_sk = user_client.get_scoped_key(_transformation, scope_test)
         cs_sks = user_client.get_transformation_chemicalsystems(tf_sk)
 
-        assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
-            transformation.stateA.key,
-            transformation.stateB.key,
-        ]
+        if transformation_class_name is "Transformation":
+            assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
+                _transformation.stateA.key,
+                _transformation.stateB.key,
+            ]
+        elif transformation_class_name is "NonTransformation":
+            assert len(cs_sks) == 1
+            assert cs_sks[0].gufe_key == _transformation.system.key
 
     def test_get_chemicalsystem_transformations(
         self,

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -422,12 +422,12 @@ class TestNeo4jStore(TestStateStore):
         tf_sk = ScopedKey(gufe_key=_transformation.key, **scope_test.dict())
         cs_sks = n4js.get_transformation_chemicalsystems(tf_sk)
 
-        if transformation_class_name is "Transformation":
+        if transformation_class_name == "Transformation":
             assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
                 _transformation.stateA.key,
                 _transformation.stateB.key,
             ]
-        elif transformation_class_name is "NonTransformation":
+        elif transformation_class_name == "NonTransformation":
             assert len(cs_sks) == 1
             assert cs_sks[0].gufe_key == _transformation.system.key
 

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -396,20 +396,40 @@ class TestNeo4jStore(TestStateStore):
         assert sk in an_sks
         assert len(an_sks) == 1
 
+    @pytest.mark.parametrize(
+        "transformation_class_name", ["Transformation", "NonTransformation"]
+    )
     def test_get_transformation_chemicalsystems(
-        self, n4js, network_tyk2, scope_test, transformation
+        self,
+        n4js,
+        network_tyk2,
+        scope_test,
+        transformation,
+        nontransformation,
+        transformation_class_name,
     ):
         an = network_tyk2
         n4js.assemble_network(an, scope_test)
 
-        tf_sk = ScopedKey(gufe_key=transformation.key, **scope_test.dict())
+        match transformation_class_name:
+            case "Transformation":
+                _transformation = transformation
+            case "NonTransformation":
+                _transformation = nontransformation
+            case _:
+                raise ValueError('Expected "Transformation" or "NonTransformation"')
 
+        tf_sk = ScopedKey(gufe_key=_transformation.key, **scope_test.dict())
         cs_sks = n4js.get_transformation_chemicalsystems(tf_sk)
 
-        assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
-            transformation.stateA.key,
-            transformation.stateB.key,
-        ]
+        if transformation_class_name is "Transformation":
+            assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
+                _transformation.stateA.key,
+                _transformation.stateB.key,
+            ]
+        elif transformation_class_name is "NonTransformation":
+            assert len(cs_sks) == 1
+            assert cs_sks[0].gufe_key == _transformation.system.key
 
     def test_get_chemicalsystem_transformations(
         self, n4js, network_tyk2, scope_test, chemicalsystem

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -406,11 +406,10 @@ class TestNeo4jStore(TestStateStore):
 
         cs_sks = n4js.get_transformation_chemicalsystems(tf_sk)
 
-        assert len(cs_sks) == 2
-        assert {cs_sk.gufe_key for cs_sk in cs_sks} == {
+        assert [cs_sk.gufe_key for cs_sk in cs_sks] == [
             transformation.stateA.key,
             transformation.stateB.key,
-        }
+        ]
 
     def test_get_chemicalsystem_transformations(
         self, n4js, network_tyk2, scope_test, chemicalsystem

--- a/news/get_transformation_chemicalsystems_ordering.rst
+++ b/news/get_transformation_chemicalsystems_ordering.rst
@@ -1,0 +1,7 @@
+**Changed:**
+
+* Updated ``AlchemiscaleClient.get_transformation_chemicalsystems`` method:
+  * Now returns the ``ScopedKeys`` of a given ``Transformation`` ordered by the states they represent:
+    * The first ``ScopedKey`` corresponds to the ``ChemicalSystem`` for ``stateA``.
+    * The second ``ScopedKey`` corresponds to the ``ChemicalSystem`` for ``stateB``.
+  * If provided with a ``NonTransformation`` ``ScopedKey``, the method returns a list containing only the single key representing the ``system``.


### PR DESCRIPTION
This PR adjusts the order of the returned `ChemicalSystem` `ScopedKey` objects such that they are sorted by the attribute name. For a `Transformation` this means that the `ScopedKey` list will have two elements, the first representing the `ChemicalSystem` of "stateA" and the second representing the `ChemicalSystem` of "stateB". If a `NonTransformation` is given, then we will return a list with a single element.

Although the issue mentions returning a `tuple`, it would break the current pattern present across much the API, which often returns lists of unknown sizes.

closes #294