### PR TITLE
Switch docs to furo theme

### DIFF
--- a/devtools/conda-envs/docs.yml
+++ b/devtools/conda-envs/docs.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python<3.13
   - sphinx
-  - sphinx-rtd-theme
+  - furo
   - myst-nb
   - myst-parser>=0.14
   - docutils

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@ author = '"OpenFE and OpenFF developers"'
 
 import sys
 import os
-import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("."))
 
@@ -58,7 +57,7 @@ intersphinx_mapping = {
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # -- Options for MystNB ------------------------------------------------------
 


### PR DESCRIPTION
Switching docs to furo theme, in line with `gufe` docs: https://gufe.openfree.energy/en/latest/
