### PR TITLE
Update test env to latest deps

### DIFF
--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -7,8 +7,8 @@ dependencies:
   - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe=1.3.0
-  - openfe=1.4.0
+  - gufe=1.6.0
+  - openfe=1.6.0
   - pydantic >2
   - pydantic-settings
   - async-lru
@@ -52,9 +52,8 @@ dependencies:
   - moto
 
   # additional pins
-  - openmm=8.1.2
+  - openmm=8.2.0
   - openmmforcefields>=0.14.2
-  - openff-units=0.2.2
 
   - pip:
     - git+https://github.com/datryllic/grolt # neo4j test server deployment


### PR DESCRIPTION
Includes:
- `gufe` v1.6.0
- `openfe` v1.6.0
- `openmm` v8.2.0


We want to check that we also get in latest `openff-toolkit` and `openff-interchange`, as well as `nagl` and `pytorch` as dependencies.
