### PR TITLE
update treafik to v2.11

### DIFF
--- a/docker/alchemiscale-server/docker-compose.yml
+++ b/docker/alchemiscale-server/docker-compose.yml
@@ -174,7 +174,7 @@ services:
 
   reverse-proxy:
     # The official v2 Traefik docker image
-    image: traefik:v2.9
+    image: traefik:v2.11
     networks:
       - internal
       - web


### PR DESCRIPTION
A just updated my ubuntu docker and stared seeing errors like this 


```
reverse-proxy-1         | time="2025-11-18T10:17:25Z" level=error msg="Failed to retrieve information of the docker client and server host: Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version" providerName=docker
```

Traefik v2.9 is from 2022, so makes sense we're a little behind – updating to the latest-compatible with v2, ie 2.11