### PR TITLE
Review and address v0.8.0 milestone issues

### DIFF
--- a/alchemiscale/__init__.py
+++ b/alchemiscale/__init__.py
@@ -1,4 +1,4 @@
-from .interface import AlchemiscaleClient
+from .interface import AlchemiscaleClient, ResultFormat
 from .models import Scope, ScopedKey
 
 from importlib.metadata import version

--- a/alchemiscale/interface/__init__.py
+++ b/alchemiscale/interface/__init__.py
@@ -1,1 +1,1 @@
-from .client import AlchemiscaleClient
+from .client import AlchemiscaleClient, ResultFormat

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -4,6 +4,8 @@
 
 """
 
+from __future__ import annotations
+
 import asyncio
 from enum import StrEnum
 from typing import Any, Literal
@@ -52,6 +54,7 @@ class ResultFormat(StrEnum):
     PROTOCOL_DAG_RESULTS
         Return the raw list of ProtocolDAGResults.
     """
+
     PROTOCOL_RESULT = "ProtocolResult"
     PROTOCOL_RESULTS = "ProtocolResults"
     PROTOCOL_DAG_RESULTS = "ProtocolDAGResults"
@@ -1633,10 +1636,15 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         self,
         network: ScopedKey,
         ok: bool = True,
-        return_as: ResultFormat | Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"] = ResultFormat.PROTOCOL_RESULT,
+        return_as: (
+            ResultFormat
+            | Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"]
+        ) = ResultFormat.PROTOCOL_RESULT,
         compress: bool = True,
         visualize: bool = True,
-    ) -> dict[str, ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]]:
+    ) -> dict[
+        str, ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]
+    ]:
         import multiprocessing as mp
         from concurrent.futures import ProcessPoolExecutor, as_completed
 
@@ -1694,11 +1702,16 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_network_results(
         self,
         network: ScopedKey,
-        return_as: ResultFormat | Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"] = ResultFormat.PROTOCOL_RESULT,
+        return_as: (
+            ResultFormat
+            | Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"]
+        ) = ResultFormat.PROTOCOL_RESULT,
         return_protocoldagresults: bool | None = None,
         compress: bool = True,
         visualize: bool = True,
-    ) -> dict[str, ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]]:
+    ) -> dict[
+        str, ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]
+    ]:
         r"""Get a `ProtocolResult` for every `Transformation` in the given
         `AlchemicalNetwork`.
 
@@ -1786,7 +1799,10 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_transformation_results(
         self,
         transformation: ScopedKey,
-        return_as: ResultFormat | Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"] = ResultFormat.PROTOCOL_RESULT,
+        return_as: (
+            ResultFormat
+            | Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"]
+        ) = ResultFormat.PROTOCOL_RESULT,
         return_protocoldagresults: bool | None = None,
         compress: bool = True,
         visualize: bool = True,
@@ -1840,7 +1856,12 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
                 return_as = ResultFormat.PROTOCOL_DAG_RESULTS
 
         # Get the transformation if we need to create ProtocolResult(s)
-        if return_as in (ResultFormat.PROTOCOL_RESULT, ResultFormat.PROTOCOL_RESULTS, "ProtocolResult", "ProtocolResults"):
+        if return_as in (
+            ResultFormat.PROTOCOL_RESULT,
+            ResultFormat.PROTOCOL_RESULTS,
+            "ProtocolResult",
+            "ProtocolResults",
+        ):
             tf: Transformation = self.get_transformation(
                 transformation, visualize=visualize
             )

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -1725,6 +1725,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         return_as
             Determines the format of returned results for each `Transformation`.
             Can be a `ResultFormat` enum value or string. Options:
+
             - ``ResultFormat.PROTOCOL_RESULT`` or ``'ProtocolResult'`` (default):
               Return a single aggregated `ProtocolResult` combining all successful
               `ProtocolDAGResult`\s. If no results exist, ``None`` is given.
@@ -1822,6 +1823,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         return_as
             Determines the format of returned results. Can be a `ResultFormat`
             enum value or string. Options:
+
             - ``ResultFormat.PROTOCOL_RESULT`` or ``'ProtocolResult'`` (default):
               Return a single aggregated `ProtocolResult` combining all successful
               `ProtocolDAGResult`\s.

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -5,7 +5,7 @@
 """
 
 import asyncio
-from typing import Any
+from typing import Any, Literal
 from collections.abc import Iterable
 from itertools import chain
 from functools import lru_cache
@@ -1615,10 +1615,10 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         self,
         network: ScopedKey,
         ok: bool = True,
-        return_protocoldagresults: bool = False,
+        return_as: Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"] = "ProtocolResult",
         compress: bool = True,
         visualize: bool = True,
-    ) -> dict[str, ProtocolResult | None | list[ProtocolDAGResult]]:
+    ) -> dict[str, ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]]:
         import multiprocessing as mp
         from concurrent.futures import ProcessPoolExecutor, as_completed
 
@@ -1626,7 +1626,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
         if ok:
             kwargs = dict(
-                return_protocoldagresults=return_protocoldagresults,
+                return_as=return_as,
                 compress=compress,
                 visualize=False,
             )
@@ -1676,30 +1676,35 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_network_results(
         self,
         network: ScopedKey,
-        return_protocoldagresults: bool = False,
+        return_as: Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"] = "ProtocolResult",
+        return_protocoldagresults: bool | None = None,
         compress: bool = True,
         visualize: bool = True,
-    ) -> dict[str, ProtocolResult | None | list[ProtocolDAGResult]]:
+    ) -> dict[str, ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]]:
         r"""Get a `ProtocolResult` for every `Transformation` in the given
         `AlchemicalNetwork`.
 
         A dict giving the `ScopedKey` of each `Transformation` in the network
-        as keys, `ProtocolResult` as values, is returned. If no
-        `ProtocolDAGResult`\s exist for a given `Transformation`, ``None`` is
-        given for its value.
-
-        If `return_protocoldagresults` is ``True``, then a list of the
-        `ProtocolDAGResult`\s themselves is given as values instead of
-        `ProtocolResult`\s.
+        as keys, with values determined by the `return_as` parameter.
 
         Parameters
         ----------
         network
             The `ScopedKey` of the `AlchemicalNetwork` to retrieve results for.
+        return_as
+            Determines the format of returned results for each `Transformation`. Options:
+            - ``'ProtocolResult'`` (default): Return a single aggregated
+              `ProtocolResult` combining all successful `ProtocolDAGResult`\s.
+              If no results exist, ``None`` is given.
+            - ``'ProtocolResults'``: Return a list of individual `ProtocolResult`\s,
+              one for each successful `ProtocolDAGResult`. Returns empty list if
+              no results exist.
+            - ``'ProtocolDAGResults'``: Return a list of the raw
+              `ProtocolDAGResult`\s.
         return_protocoldagresults
-            If ``True``, return the raw `ProtocolDAGResult`s instead of returning
-            a processed `ProtocolResult`. Only successful `ProtocolDAGResult`\s
-            are returned.
+            .. deprecated:: 0.8.0
+                Use `return_as` instead. If ``True``, equivalent to
+                ``return_as='ProtocolDAGResults'``.
         compress
             If ``True``, compress the ProtocolDAGResults server-side before
             shipping them to the client. This can reduce retrieval time depending
@@ -1710,10 +1715,21 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             If ``True``, show retrieval progress indicators.
 
         """
+        # Handle backward compatibility
+        if return_protocoldagresults is not None:
+            warn(
+                "The 'return_protocoldagresults' parameter is deprecated and will be "
+                "removed in a future version. Use 'return_as' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if return_protocoldagresults:
+                return_as = "ProtocolDAGResults"
+
         return self._get_network_results(
             network=network,
             ok=True,
-            return_protocoldagresults=return_protocoldagresults,
+            return_as=return_as,
             compress=compress,
             visualize=visualize,
         )
@@ -1751,10 +1767,11 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
     def get_transformation_results(
         self,
         transformation: ScopedKey,
-        return_protocoldagresults: bool = False,
+        return_as: Literal["ProtocolResult", "ProtocolResults", "ProtocolDAGResults"] = "ProtocolResult",
+        return_protocoldagresults: bool | None = None,
         compress: bool = True,
         visualize: bool = True,
-    ) -> ProtocolResult | None | list[ProtocolDAGResult]:
+    ) -> ProtocolResult | None | list[ProtocolResult] | list[ProtocolDAGResult]:
         r"""Get a `ProtocolResult` for the given `Transformation`.
 
         A `ProtocolResult` object corresponds to the `Protocol` used for this
@@ -1763,17 +1780,22 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         `Transformation.gather`. If no `ProtocolDAGResult`\s exist for this
         `Transformation`, ``None`` is returned.
 
-        If `return_protocoldagresults` is ``True``, then a list of the
-        `ProtocolDAGResult`\s themselves is returned instead.
-
         Parameters
         ----------
         transformation
             The `ScopedKey` of the `Transformation` to retrieve results for.
+        return_as
+            Determines the format of returned results. Options:
+            - ``'ProtocolResult'`` (default): Return a single aggregated
+              `ProtocolResult` combining all successful `ProtocolDAGResult`\s.
+            - ``'ProtocolResults'``: Return a list of individual `ProtocolResult`\s,
+              one for each successful `ProtocolDAGResult`.
+            - ``'ProtocolDAGResults'``: Return a list of the raw
+              `ProtocolDAGResult`\s.
         return_protocoldagresults
-            If ``True``, return the raw `ProtocolDAGResult`s instead of returning
-            a processed `ProtocolResult`. Only successful `ProtocolDAGResult`\s
-            are returned.
+            .. deprecated:: 0.8.0
+                Use `return_as` instead. If ``True``, equivalent to
+                ``return_as='ProtocolDAGResults'``.
         compress
             If ``True``, compress the ProtocolDAGResults server-side before
             shipping them to the client. This can reduce retrieval time depending
@@ -1784,9 +1806,19 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             If ``True``, show retrieval progress indicators.
 
         """
+        # Handle backward compatibility
+        if return_protocoldagresults is not None:
+            warn(
+                "The 'return_protocoldagresults' parameter is deprecated and will be "
+                "removed in a future version. Use 'return_as' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if return_protocoldagresults:
+                return_as = "ProtocolDAGResults"
 
-        if not return_protocoldagresults:
-            # get the transformation if we intend to return a ProtocolResult
+        # Get the transformation if we need to create ProtocolResult(s)
+        if return_as in ("ProtocolResult", "ProtocolResults"):
             tf: Transformation = self.get_transformation(
                 transformation, visualize=visualize
             )
@@ -1804,9 +1836,15 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             visualize=visualize,
         )
 
-        if return_protocoldagresults:
+        if return_as == "ProtocolDAGResults":
             return pdrs
-        else:
+        elif return_as == "ProtocolResults":
+            # Return individual ProtocolResults for each ProtocolDAGResult
+            if len(pdrs) == 0:
+                return []
+            return [tf.gather([pdr]) for pdr in pdrs]
+        else:  # return_as == "ProtocolResult"
+            # Return aggregated ProtocolResult
             if len(pdrs) != 0:
                 return tf.gather(pdrs)
             else:

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -2328,11 +2328,13 @@ class TestClient:
 
         # Test new return_as parameter with 'ProtocolResults'
         protocolresults_list = user_client.get_transformation_results(
-            transformation_sk, return_as='ProtocolResults'
+            transformation_sk, return_as="ProtocolResults"
         )
 
         assert isinstance(protocolresults_list, list)
-        assert len(protocolresults_list) == 3  # Should have 3 individual ProtocolResults
+        assert (
+            len(protocolresults_list) == 3
+        )  # Should have 3 individual ProtocolResults
 
         for pr in protocolresults_list:
             assert isinstance(pr, ProtocolResult)
@@ -2341,6 +2343,7 @@ class TestClient:
 
         # Test backward compatibility: old parameter should still work with deprecation warning
         import warnings
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             protocoldagresults_old = user_client.get_transformation_results(
@@ -2370,7 +2373,7 @@ class TestClient:
 
         # Test network-level return_as='ProtocolResults'
         network_results_list = user_client.get_network_results(
-            network_sk, return_as='ProtocolResults'
+            network_sk, return_as="ProtocolResults"
         )
         for tf_sk, prs in network_results_list.items():
             if tf_sk == transformation_sk:

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -8,6 +8,7 @@ import json
 
 from gufe import AlchemicalNetwork
 from gufe.tokenization import TOKENIZABLE_REGISTRY, GufeKey, JSON_HANDLER
+from gufe.protocols import ProtocolResult
 from gufe.protocols.protocoldag import execute_DAG
 import networkx as nx
 
@@ -2289,7 +2290,7 @@ class TestClient:
 
         # get back protocoldagresults instead
         protocoldagresults_r = user_client.get_transformation_results(
-            transformation_sk, return_protocoldagresults=True
+            transformation_sk, return_as=ResultFormat.PROTOCOL_DAG_RESULTS
         )
 
         assert set(protocoldagresults_r) == set(protocoldagresults)
@@ -2312,7 +2313,7 @@ class TestClient:
                 assert pr is None
 
         network_results = user_client.get_network_results(
-            network_sk, return_protocoldagresults=True
+            network_sk, return_as=ResultFormat.PROTOCOL_DAG_RESULTS
         )
         for tf_sk, pdrs in network_results.items():
             if tf_sk == transformation_sk:

--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -434,11 +434,15 @@ If there are complete :py:class:`~alchemiscale.storage.models.Task`\s, we can pu
 
 This object features a :external+gufe:py:meth:`~gufe.protocols.protocol.ProtocolResult.get_estimate` and :external+gufe:py:meth:`~gufe.protocols.protocol.ProtocolResult.get_uncertainty` method, giving the best available estimate of the free energy difference and its uncertainty. 
 
-To pull the :external+gufe:py:class:`~gufe.protocols.protocoldag.ProtocolDAGResult`\s and not combine them into a :external+gufe:py:class:`~gufe.protocols.protocol.ProtocolResult` object, you can give ``return_protocoldagresults=True`` to this method.
+To get individual :external+gufe:py:class:`~gufe.protocols.protocol.ProtocolResult`\s for each :external+gufe:py:class:`~gufe.protocols.protocoldag.ProtocolDAGResult` rather than a single aggregated result, use ``return_as='ProtocolResults'``::
+
+    >>> from alchemiscale import ResultFormat
+    >>> protocol_results = asc.get_transformation_results(tf_sk, return_as=ResultFormat.PROTOCOL_RESULTS)
+
+To pull the raw :external+gufe:py:class:`~gufe.protocols.protocoldag.ProtocolDAGResult`\s, use ``return_as='ProtocolDAGResults'``.
 Any number of :external+gufe:py:class:`~gufe.protocols.protocoldag.ProtocolDAGResult`\s can then be manually combined into a single :external+gufe:py:class:`~gufe.protocols.protocol.ProtocolResult` with::
 
-    >>> # protocol_dag_results: List[ProtocolDAGResult]
-    >>> protocol_dag_results = asc.get_transformation_results(tf_sk, return_protocoldagresults=True)
+    >>> protocol_dag_results = asc.get_transformation_results(tf_sk, return_as=ResultFormat.PROTOCOL_DAG_RESULTS)
     >>> protocol_result = transformation.gather(protocol_dag_results)
     >>> protocol_result
     <RelativeHybridTopologyProtocolResult-44b0f588f5f3073aa58d86e1017ef623>


### PR DESCRIPTION
Implements #474 by replacing the `return_protocoldagresults` boolean parameter with a new `return_as` parameter that accepts three string options:

- 'ProtocolResult' (default): Returns aggregated ProtocolResult combining all successful ProtocolDAGResults via Transformation.gather()
- 'ProtocolResults': Returns a list of individual ProtocolResults, one for each successful ProtocolDAGResult by calling gather([pdr]) on each
- 'ProtocolDAGResults': Returns the raw list of ProtocolDAGResults

Changes:
- Updated get_transformation_results() with new return_as parameter
- Updated get_network_results() with new return_as parameter
- Updated _get_network_results() helper to pass return_as
- Added deprecation warning for return_protocoldagresults parameter
- Added comprehensive tests for new functionality and backward compatibility
- Updated type hints to reflect new return types

The old return_protocoldagresults parameter is maintained for backward compatibility but deprecated with a warning.