### PR TITLE
Address issue #222

### DIFF
--- a/alchemiscale/compute/api.py
+++ b/alchemiscale/compute/api.py
@@ -218,6 +218,7 @@ def claim_taskhub_tasks(
 @router.post("/claim")
 def claim_tasks(
     scopes: list[Scope] = Body(),
+    scopes_exclude: list[Scope] | None = Body(None, embed=True),
     compute_service_id: str = Body(),
     count: int = Body(),
     protocols: list[str] | None = Body(None, embed=True),
@@ -255,6 +256,20 @@ def claim_tasks(
     # loop might be more removable in the future with a Union like operator on scopes
     for single_query_scope in set(query_scopes):
         taskhubs.update(n4js.query_taskhubs(scope=single_query_scope, return_gufe=True))
+
+    # filter out taskhubs that match excluded scopes
+    if scopes_exclude:
+        taskhubs_filtered = {}
+        for taskhub_sk, taskhub in taskhubs.items():
+            exclude = False
+            for exclude_scope in scopes_exclude:
+                # if the exclude scope is a superset of the taskhub scope, exclude it
+                if exclude_scope.is_superset(taskhub_sk.scope):
+                    exclude = True
+                    break
+            if not exclude:
+                taskhubs_filtered[taskhub_sk] = taskhub
+        taskhubs = taskhubs_filtered
 
     # list of tasks to return
     tasks = []

--- a/alchemiscale/compute/api.py
+++ b/alchemiscale/compute/api.py
@@ -258,17 +258,12 @@ def claim_tasks(
 
     # filter out taskhubs that match excluded scopes
     if scopes_exclude:
-        taskhubs_filtered = {}
-        for taskhub_sk, taskhub in taskhubs.items():
-            exclude = False
-            for exclude_scope in scopes_exclude:
-                # if the exclude scope is a superset of the taskhub scope, exclude it
-                if exclude_scope.is_superset(taskhub_sk.scope):
-                    exclude = True
-                    break
-            if not exclude:
-                taskhubs_filtered[taskhub_sk] = taskhub
-        taskhubs = taskhubs_filtered
+        scopes_exclude_reduced = minimize_scope_space(scopes_exclude)
+        taskhubs = {
+            sk: th
+            for sk, th in taskhubs.items()
+            if not any(ex.is_superset(sk.scope) for ex in scopes_exclude_reduced)
+        }
 
     # list of tasks to return
     tasks = []

--- a/alchemiscale/compute/api.py
+++ b/alchemiscale/compute/api.py
@@ -256,20 +256,24 @@ def claim_tasks(
     for single_query_scope in set(query_scopes):
         taskhubs.update(n4js.query_taskhubs(scope=single_query_scope, return_gufe=True))
 
-    # filter out taskhubs that match excluded scopes
+    # filter out taskhubs whose scope is covered by any excluded scope
     if scopes_exclude:
         scopes_exclude_reduced = minimize_scope_space(scopes_exclude)
-        taskhubs = {
-            sk: th
-            for sk, th in taskhubs.items()
-            if not any(ex.is_superset(sk.scope) for ex in scopes_exclude_reduced)
-        }
+
+        def is_excluded(taskhub_scope: Scope) -> bool:
+            return any(
+                excluded.is_superset(taskhub_scope)
+                for excluded in scopes_exclude_reduced
+            )
+
+        taskhubs = {sk: th for sk, th in taskhubs.items() if not is_excluded(sk.scope)}
 
     # list of tasks to return
     tasks = []
 
     if len(taskhubs) == 0:
-        return []
+        # match the pad-with-``None`` behavior of the normal return path below
+        return [None] * count
 
     # claim tasks from taskhubs based on weight; keep going till we hit our
     # total desired task count, or we run out of taskhubs to draw from

--- a/alchemiscale/compute/client.py
+++ b/alchemiscale/compute/client.py
@@ -99,12 +99,14 @@ class AlchemiscaleComputeClient(AlchemiscaleBaseClient):
         self,
         scopes: list[Scope],
         compute_service_id: ComputeServiceID,
+        scopes_exclude: list[Scope] | None = None,
         count: int = 1,
         protocols: list[str] | None = None,
     ):
         """Claim Tasks from TaskHubs within a list of Scopes."""
         data = dict(
             scopes=[scope.to_dict() for scope in scopes],
+            scopes_exclude=[scope.to_dict() for scope in scopes_exclude] if scopes_exclude else None,
             compute_service_id=str(compute_service_id),
             count=count,
             protocols=protocols,

--- a/alchemiscale/compute/client.py
+++ b/alchemiscale/compute/client.py
@@ -106,7 +106,11 @@ class AlchemiscaleComputeClient(AlchemiscaleBaseClient):
         """Claim Tasks from TaskHubs within a list of Scopes."""
         data = dict(
             scopes=[scope.to_dict() for scope in scopes],
-            scopes_exclude=[scope.to_dict() for scope in scopes_exclude] if scopes_exclude else None,
+            scopes_exclude=(
+                [scope.to_dict() for scope in scopes_exclude]
+                if scopes_exclude
+                else None
+            ),
             compute_service_id=str(compute_service_id),
             count=count,
             protocols=protocols,

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -97,6 +97,11 @@ class SynchronousComputeService:
         else:
             self.scopes = self.settings.scopes
 
+        if self.settings.scopes_exclude is None:
+            self.scopes_exclude = []
+        else:
+            self.scopes_exclude = self.settings.scopes_exclude
+
         self.shared_basedir = Path(self.settings.shared_basedir).absolute()
         self.shared_basedir.mkdir(exist_ok=True)
         self.keep_shared = self.settings.keep_shared
@@ -168,6 +173,7 @@ class SynchronousComputeService:
 
         tasks = self.client.claim_tasks(
             scopes=self.scopes,
+            scopes_exclude=self.scopes_exclude,
             compute_service_id=self.compute_service_id,
             count=count,
             protocols=self.settings.protocols,

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -97,10 +97,7 @@ class SynchronousComputeService:
         else:
             self.scopes = self.settings.scopes
 
-        if self.settings.scopes_exclude is None:
-            self.scopes_exclude = []
-        else:
-            self.scopes_exclude = self.settings.scopes_exclude
+        self.scopes_exclude = self.settings.scopes_exclude
 
         self.shared_basedir = Path(self.settings.shared_basedir).absolute()
         self.shared_basedir.mkdir(exist_ok=True)

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -66,6 +66,10 @@ class ComputeServiceSettings(BaseModel):
         None,
         description="Scopes to limit Task claiming to; defaults to all Scopes accessible by compute identity.",
     )
+    scopes_exclude: list[Scope] | None = Field(
+        None,
+        description="Scopes to exclude from Task claiming; applied as a filter after `scopes`.",
+    )
     protocols: list[str] | None = Field(
         None,
         description="Names of Protocols to run with this service; `None` means no restriction.",
@@ -125,6 +129,19 @@ class ComputeServiceSettings(BaseModel):
     @field_validator("scopes", mode="before")
     @classmethod
     def validate_scopes(cls, values) -> list[Scope]:
+        _values = values[:]
+        for idx, value in enumerate(_values):
+            if isinstance(value, Scope):
+                continue
+            if isinstance(value, str):
+                _values[idx] = Scope.from_str(value)
+            else:
+                raise ValueError("Unable to parse input as a Scope")
+        return _values
+
+    @field_validator("scopes_exclude", mode="before")
+    @classmethod
+    def validate_scopes_exclude(cls, values) -> list[Scope]:
         _values = values[:]
         for idx, value in enumerate(_values):
             if isinstance(value, Scope):

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -141,7 +141,9 @@ class ComputeServiceSettings(BaseModel):
 
     @field_validator("scopes_exclude", mode="before")
     @classmethod
-    def validate_scopes_exclude(cls, values) -> list[Scope]:
+    def validate_scopes_exclude(cls, values) -> list[Scope] | None:
+        if values is None:
+            return None
         _values = values[:]
         for idx, value in enumerate(_values):
             if isinstance(value, Scope):

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -128,7 +128,9 @@ class ComputeServiceSettings(BaseModel):
 
     @field_validator("scopes", mode="before")
     @classmethod
-    def validate_scopes(cls, values) -> list[Scope]:
+    def validate_scopes(cls, values) -> list[Scope] | None:
+        if values is None:
+            return None
         _values = values[:]
         for idx, value in enumerate(_values):
             if isinstance(value, Scope):

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -126,25 +126,11 @@ class ComputeServiceSettings(BaseModel):
         description="Whether to verify SSL certificate presented by the API server.",
     )
 
-    @field_validator("scopes", mode="before")
+    @field_validator("scopes", "scopes_exclude", mode="before")
     @classmethod
     def validate_scopes(cls, values) -> list[Scope] | None:
-        if values is None:
-            return None
-        _values = values[:]
-        for idx, value in enumerate(_values):
-            if isinstance(value, Scope):
-                continue
-            if isinstance(value, str):
-                _values[idx] = Scope.from_str(value)
-            else:
-                raise ValueError("Unable to parse input as a Scope")
-        return _values
-
-    @field_validator("scopes_exclude", mode="before")
-    @classmethod
-    def validate_scopes_exclude(cls, values) -> list[Scope] | None:
-        if values is None:
+        # treat ``None`` and empty list equivalently; both mean "no filter"
+        if not values:
             return None
         _values = values[:]
         for idx, value in enumerate(_values):

--- a/alchemiscale/tests/integration/compute/client/conftest.py
+++ b/alchemiscale/tests/integration/compute/client/conftest.py
@@ -77,6 +77,21 @@ def compute_client_wrong_credential(uvicorn_server, compute_api_port, compute_id
 
 
 @pytest.fixture(scope="module")
+def fully_scoped_compute_client(
+    uvicorn_server,
+    compute_api_port,
+    compute_identity,
+    fully_scoped_credentialed_compute,
+):
+    """A client whose identity has access to every scope in ``multiple_scopes``."""
+    return client.AlchemiscaleComputeClient(
+        api_url=f"http://127.0.0.1:{compute_api_port}/",
+        identifier=fully_scoped_credentialed_compute.identifier,
+        key=compute_identity["key"],
+    )
+
+
+@pytest.fixture(scope="module")
 def compute_manager_client(
     uvicorn_server,
     compute_api_port,

--- a/alchemiscale/tests/integration/compute/client/test_compute_client.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_client.py
@@ -66,12 +66,10 @@ class TestComputeClient:
         out = compute_client.register(compute_service_id)
         assert out == compute_service_id
 
-        csreg = n4js_preloaded.graph.execute_query(
-            f"""
+        csreg = n4js_preloaded.graph.execute_query(f"""
             match (csreg:ComputeServiceRegistration {{identifier: '{compute_service_id}'}})
             return csreg
-            """
-        )
+            """)
 
         assert csreg.records
         assert (

--- a/alchemiscale/tests/integration/compute/client/test_compute_client.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_client.py
@@ -233,36 +233,15 @@ class TestComputeClient:
         # register compute service id
         compute_client.register(compute_service_id)
 
-        # claim with scopes_exclude matching scope_test — should return empty
-        # since the client token only has access to scope_test
+        # excluding the only included scope leaves no candidate taskhubs;
+        # the API pads the response to ``count`` with ``None``s
         task_sks = compute_client.claim_tasks(
             scopes=[scope_test],
             scopes_exclude=[scope_test],
             compute_service_id=compute_service_id,
         )
 
-        assert task_sks == []
-
-    def test_claim_tasks_scopes_exclude_none(
-        self,
-        scope_test,
-        n4js_preloaded,
-        compute_client: client.AlchemiscaleComputeClient,
-        compute_service_id,
-        uvicorn_server,
-    ):
-        # register compute service id
-        compute_client.register(compute_service_id)
-
-        # claim with scopes_exclude=None (default) — should work normally
-        task_sks = compute_client.claim_tasks(
-            scopes=[scope_test],
-            scopes_exclude=None,
-            compute_service_id=compute_service_id,
-        )
-
-        assert len(task_sks) == 1
-        assert task_sks[0] is not None
+        assert task_sks == [None]
 
     def test_get_task_transformation(
         self,

--- a/alchemiscale/tests/integration/compute/client/test_compute_client.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_client.py
@@ -243,6 +243,37 @@ class TestComputeClient:
 
         assert task_sks == [None]
 
+    def test_claim_tasks_scopes_exclude_filters(
+        self,
+        scope_test,
+        multiple_scopes,
+        n4js_preloaded,
+        fully_scoped_compute_client: client.AlchemiscaleComputeClient,
+        compute_service_id,
+        uvicorn_server,
+    ):
+        """Demonstrate that ``scopes_exclude`` filters (rather than blocks) when
+        multiple scopes are eligible: tasks from the non-excluded scopes are
+        still claimed, but none come from the excluded scope.
+        """
+        fully_scoped_compute_client.register(compute_service_id)
+
+        # claim well beyond the total number of available tasks so we end up
+        # drawing from every non-excluded taskhub — removes dependency on the
+        # random weighted choice of taskhub.
+        task_sks = fully_scoped_compute_client.claim_tasks(
+            scopes=multiple_scopes,
+            scopes_exclude=[scope_test],
+            compute_service_id=compute_service_id,
+            count=100,
+        )
+
+        claimed = [sk for sk in task_sks if sk is not None]
+        # tasks exist in the other scopes, so the filter must not block everything
+        assert len(claimed) > 0
+        # and none of them may come from the excluded scope
+        assert all(sk.scope != scope_test for sk in claimed)
+
     def test_get_task_transformation(
         self,
         scope_test,

--- a/alchemiscale/tests/integration/compute/conftest.py
+++ b/alchemiscale/tests/integration/compute/conftest.py
@@ -129,75 +129,68 @@ def n4js_preloaded(
     return n4js
 
 
+def _make_token_data_override(scopes):
+    """Create a token data dependency override for the given scopes."""
+
+    def get_token_data_depends_override():
+        return TokenData(
+            entity="carl-compute",
+            scopes=[str(s) for s in scopes],
+        )
+
+    return get_token_data_depends_override
+
+
+def _make_compute_api_no_auth(n4js_preloaded, s3os, token_data_override):
+    """Yield a compute API app with auth bypassed using the given token override."""
+
+    def get_s3os_override():
+        return s3os
+
+    overrides = copy(api.app.dependency_overrides)
+
+    api.app.dependency_overrides[get_base_api_settings] = get_compute_settings_override
+    api.app.dependency_overrides[get_s3os_depends] = get_s3os_override
+    api.app.dependency_overrides[get_token_data_depends] = token_data_override
+    yield api.app
+    api.app.dependency_overrides = overrides
+
+
 @pytest.fixture(scope="module")
 def scope_consistent_token_data_depends_override(scope_test):
     """Make a consistent helper to provide an override to the api.app while still accessing fixtures"""
-
-    def get_token_data_depends_override():
-        token_data = TokenData(entity="carl-compute", scopes=[str(scope_test)])
-        return token_data
-
-    return get_token_data_depends_override
+    return _make_token_data_override([scope_test])
 
 
 @pytest.fixture
 def compute_api_no_auth(
     n4js_preloaded, s3os, scope_consistent_token_data_depends_override
 ):
-    def get_s3os_override():
-        return s3os
-
-    overrides = copy(api.app.dependency_overrides)
-    get_token_data_depends_override = scope_consistent_token_data_depends_override
-
-    api.app.dependency_overrides[get_base_api_settings] = get_compute_settings_override
-    api.app.dependency_overrides[get_s3os_depends] = get_s3os_override
-    api.app.dependency_overrides[get_token_data_depends] = (
-        get_token_data_depends_override
+    yield from _make_compute_api_no_auth(
+        n4js_preloaded, s3os, scope_consistent_token_data_depends_override
     )
-    yield api.app
-    api.app.dependency_overrides = overrides
 
 
 @pytest.fixture
 def test_client(compute_api_no_auth):
-    client = TestClient(compute_api_no_auth)
-    return client
+    return TestClient(compute_api_no_auth)
 
 
 @pytest.fixture(scope="module")
 def multi_scope_token_data_depends_override(multiple_scopes):
     """Token data override granting access to all test scopes."""
-
-    def get_token_data_depends_override():
-        token_data = TokenData(
-            entity="carl-compute",
-            scopes=[str(s) for s in multiple_scopes],
-        )
-        return token_data
-
-    return get_token_data_depends_override
+    return _make_token_data_override(multiple_scopes)
 
 
 @pytest.fixture
 def multi_scope_compute_api_no_auth(
     n4js_preloaded, s3os, multi_scope_token_data_depends_override
 ):
-    def get_s3os_override():
-        return s3os
-
-    overrides = copy(api.app.dependency_overrides)
-
-    api.app.dependency_overrides[get_base_api_settings] = get_compute_settings_override
-    api.app.dependency_overrides[get_s3os_depends] = get_s3os_override
-    api.app.dependency_overrides[get_token_data_depends] = (
-        multi_scope_token_data_depends_override
+    yield from _make_compute_api_no_auth(
+        n4js_preloaded, s3os, multi_scope_token_data_depends_override
     )
-    yield api.app
-    api.app.dependency_overrides = overrides
 
 
 @pytest.fixture
 def multi_scope_test_client(multi_scope_compute_api_no_auth):
-    client = TestClient(multi_scope_compute_api_no_auth)
-    return client
+    return TestClient(multi_scope_compute_api_no_auth)

--- a/alchemiscale/tests/integration/compute/test_compute_api.py
+++ b/alchemiscale/tests/integration/compute/test_compute_api.py
@@ -1,12 +1,9 @@
-import json
-
 import pytest
 
 from gufe import Transformation
 
 from alchemiscale.base.client import json_to_gufe
 from alchemiscale.models import Scope, ScopedKey
-from alchemiscale.storage.models import ComputeServiceID
 
 
 class TestComputeAPI:
@@ -122,7 +119,7 @@ class TestComputeAPI:
         # register a compute service
         multi_scope_test_client.post(
             f"/computeservice/{compute_service_id}/register",
-            content=json.dumps({"compute_manager_id": None}),
+            json={"compute_manager_id": None},
         )
 
         # claim tasks with all scopes, no exclusions
@@ -133,7 +130,7 @@ class TestComputeAPI:
             count=1,
             protocols=None,
         )
-        response = multi_scope_test_client.post("/claim", content=json.dumps(data))
+        response = multi_scope_test_client.post("/claim", json=data)
         assert response.status_code == 200
         tasks_no_exclude = response.json()
         assert len(tasks_no_exclude) == 1
@@ -147,9 +144,7 @@ class TestComputeAPI:
             count=1,
             protocols=None,
         )
-        response = multi_scope_test_client.post(
-            "/claim", content=json.dumps(data_with_exclude)
-        )
+        response = multi_scope_test_client.post("/claim", json=data_with_exclude)
         assert response.status_code == 200
         tasks_with_exclude = response.json()
         assert len(tasks_with_exclude) == 1
@@ -169,7 +164,7 @@ class TestComputeAPI:
         # register a compute service
         multi_scope_test_client.post(
             f"/computeservice/{compute_service_id}/register",
-            content=json.dumps({"compute_manager_id": None}),
+            json={"compute_manager_id": None},
         )
 
         # exclude all scopes — should return empty list
@@ -180,7 +175,7 @@ class TestComputeAPI:
             count=1,
             protocols=None,
         )
-        response = multi_scope_test_client.post("/claim", content=json.dumps(data))
+        response = multi_scope_test_client.post("/claim", json=data)
         assert response.status_code == 200
         assert response.json() == []
 
@@ -195,7 +190,7 @@ class TestComputeAPI:
         # register a compute service
         multi_scope_test_client.post(
             f"/computeservice/{compute_service_id}/register",
-            content=json.dumps({"compute_manager_id": None}),
+            json={"compute_manager_id": None},
         )
 
         # exclude with a wildcard scope that matches everything
@@ -207,6 +202,6 @@ class TestComputeAPI:
             count=1,
             protocols=None,
         )
-        response = multi_scope_test_client.post("/claim", content=json.dumps(data))
+        response = multi_scope_test_client.post("/claim", json=data)
         assert response.status_code == 200
         assert response.json() == []

--- a/alchemiscale/tests/integration/compute/test_compute_api.py
+++ b/alchemiscale/tests/integration/compute/test_compute_api.py
@@ -115,43 +115,38 @@ class TestComputeAPI:
         scope_test,
         compute_service_id,
     ):
-        """Test that scopes_exclude filters out taskhubs matching excluded scopes."""
+        """Test that scopes_exclude filters out taskhubs matching excluded scopes.
+
+        Claims enough tasks to exhaust all eligible taskhubs so the assertion
+        does not depend on the random weighted choice of taskhub.
+        """
         # register a compute service
         multi_scope_test_client.post(
             f"/computeservice/{compute_service_id}/register",
             json={"compute_manager_id": None},
         )
 
-        # claim tasks with all scopes, no exclusions
-        data = dict(
-            scopes=[s.to_dict() for s in multiple_scopes],
-            scopes_exclude=None,
-            compute_service_id=str(compute_service_id),
-            count=1,
-            protocols=None,
-        )
-        response = multi_scope_test_client.post("/claim", json=data)
-        assert response.status_code == 200
-        tasks_no_exclude = response.json()
-        assert len(tasks_no_exclude) == 1
-        assert tasks_no_exclude[0] is not None
+        # claim well beyond the total number of available tasks so we end up
+        # drawing from every non-excluded taskhub
+        claim_count = 100
 
-        # claim tasks excluding scope_test — should still get tasks from other scopes
+        # claim tasks excluding scope_test — should still get tasks from
+        # the other scopes, but none from scope_test
         data_with_exclude = dict(
             scopes=[s.to_dict() for s in multiple_scopes],
             scopes_exclude=[scope_test.to_dict()],
             compute_service_id=str(compute_service_id),
-            count=1,
+            count=claim_count,
             protocols=None,
         )
         response = multi_scope_test_client.post("/claim", json=data_with_exclude)
         assert response.status_code == 200
-        tasks_with_exclude = response.json()
-        assert len(tasks_with_exclude) == 1
-        # the claimed task should not be from scope_test
-        if tasks_with_exclude[0] is not None:
-            claimed_sk = ScopedKey.from_str(tasks_with_exclude[0])
-            assert claimed_sk.scope != scope_test
+
+        claimed = [ScopedKey.from_str(t) for t in response.json() if t is not None]
+        # we must actually claim something — there are tasks in the other scopes
+        assert len(claimed) > 0
+        # and none of them may come from the excluded scope
+        assert all(sk.scope != scope_test for sk in claimed)
 
     def test_claim_tasks_scopes_exclude_all(
         self,
@@ -160,24 +155,25 @@ class TestComputeAPI:
         multiple_scopes,
         compute_service_id,
     ):
-        """Test that excluding all scopes returns an empty list."""
+        """Test that excluding all scopes claims no tasks."""
         # register a compute service
         multi_scope_test_client.post(
             f"/computeservice/{compute_service_id}/register",
             json={"compute_manager_id": None},
         )
 
-        # exclude all scopes — should return empty list
+        # exclude all scopes — every slot of the response should be ``None``
+        count = 3
         data = dict(
             scopes=[s.to_dict() for s in multiple_scopes],
             scopes_exclude=[s.to_dict() for s in multiple_scopes],
             compute_service_id=str(compute_service_id),
-            count=1,
+            count=count,
             protocols=None,
         )
         response = multi_scope_test_client.post("/claim", json=data)
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == [None] * count
 
     def test_claim_tasks_scopes_exclude_wildcard(
         self,
@@ -195,13 +191,14 @@ class TestComputeAPI:
 
         # exclude with a wildcard scope that matches everything
         wildcard_scope = Scope()  # org=None, campaign=None, project=None => *-*-*
+        count = 3
         data = dict(
             scopes=[s.to_dict() for s in multiple_scopes],
             scopes_exclude=[wildcard_scope.to_dict()],
             compute_service_id=str(compute_service_id),
-            count=1,
+            count=count,
             protocols=None,
         )
         response = multi_scope_test_client.post("/claim", json=data)
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == [None] * count

--- a/alchemiscale/tests/unit/compute/test_settings.py
+++ b/alchemiscale/tests/unit/compute/test_settings.py
@@ -30,3 +30,31 @@ class TestComputeServiceSettings:
         with pytest.raises(ValueError):
             scopes = ["*.*.*", "*-*-*"]
             ComputeServiceSettings.validate_scopes(scopes)
+
+    def test_validate_scopes_exclude(self):
+        orgs = ["testorg", "*"]
+        campaigns = ["testcompaign", "*"]
+        projects = ["testproject", "*"]
+
+        scopes = []
+        for org in orgs:
+            for campaign in campaigns:
+                if org == "*" and campaign != "*":
+                    continue
+                for project in projects:
+                    if campaign == "*" and project != "*":
+                        continue
+                    string_rep = f"{org}-{campaign}-{project}"
+                    scopes.append(string_rep)
+                    scopes.append(Scope.from_str(string_rep))
+
+        assert ComputeServiceSettings.validate_scopes_exclude(scopes) == list(
+            map(lambda s: Scope.from_str(s) if type(s) is str else s, scopes)
+        )
+
+        with pytest.raises(ValueError):
+            scopes = ["*.*.*", "*-*-*"]
+            ComputeServiceSettings.validate_scopes_exclude(scopes)
+
+    def test_validate_scopes_exclude_none(self):
+        assert ComputeServiceSettings.validate_scopes_exclude(None) is None

--- a/alchemiscale/tests/unit/compute/test_settings.py
+++ b/alchemiscale/tests/unit/compute/test_settings.py
@@ -31,6 +31,9 @@ class TestComputeServiceSettings:
             scopes = ["*.*.*", "*-*-*"]
             ComputeServiceSettings.validate_scopes(scopes)
 
+    def test_validate_scopes_none(self):
+        assert ComputeServiceSettings.validate_scopes(None) is None
+
     def test_validate_scopes_exclude(self):
         orgs = ["testorg", "*"]
         campaigns = ["testcompaign", "*"]

--- a/alchemiscale/tests/unit/compute/test_settings.py
+++ b/alchemiscale/tests/unit/compute/test_settings.py
@@ -31,33 +31,7 @@ class TestComputeServiceSettings:
             scopes = ["*.*.*", "*-*-*"]
             ComputeServiceSettings.validate_scopes(scopes)
 
-    def test_validate_scopes_none(self):
-        assert ComputeServiceSettings.validate_scopes(None) is None
-
-    def test_validate_scopes_exclude(self):
-        orgs = ["testorg", "*"]
-        campaigns = ["testcompaign", "*"]
-        projects = ["testproject", "*"]
-
-        scopes = []
-        for org in orgs:
-            for campaign in campaigns:
-                if org == "*" and campaign != "*":
-                    continue
-                for project in projects:
-                    if campaign == "*" and project != "*":
-                        continue
-                    string_rep = f"{org}-{campaign}-{project}"
-                    scopes.append(string_rep)
-                    scopes.append(Scope.from_str(string_rep))
-
-        assert ComputeServiceSettings.validate_scopes_exclude(scopes) == list(
-            map(lambda s: Scope.from_str(s) if type(s) is str else s, scopes)
-        )
-
-        with pytest.raises(ValueError):
-            scopes = ["*.*.*", "*-*-*"]
-            ComputeServiceSettings.validate_scopes_exclude(scopes)
-
-    def test_validate_scopes_exclude_none(self):
-        assert ComputeServiceSettings.validate_scopes_exclude(None) is None
+    @pytest.mark.parametrize("values", [None, []])
+    def test_validate_scopes_empty(self, values):
+        # ``None`` and an empty list are both treated as "no filter"
+        assert ComputeServiceSettings.validate_scopes(values) is None

--- a/news/issue-222.rst
+++ b/news/issue-222.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* Compute services now accept a ``scopes_exclude`` setting that filters out
+  ``TaskHub``\s in matching ``Scope``\s when claiming tasks; applied as a
+  filter after ``scopes``.
+
+**Changed:**
+
+* The compute API ``/claim`` endpoint now consistently pads its response with
+  ``None`` up to the requested ``count`` when no eligible ``TaskHub``\s remain
+  after scope filtering, matching the behavior of the normal claim path.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This commit introduces a new `scopes_exclude` configuration parameter for compute services, addressing issue #222.

Changes:
- Added `scopes_exclude` field to ComputeServiceSettings with validation
- Updated ComputeService to initialize and pass scopes_exclude to client
- Updated ComputeClient.claim_tasks() to accept and transmit scopes_exclude
- Updated compute API /claim endpoint to filter taskhubs based on excluded scopes
- Filtering uses Scope.is_superset() to exclude taskhubs matching excluded scopes

The scopes_exclude option is applied after scopes as a filter, allowing users to specify broad scopes while excluding specific subset scopes from task claiming.

Fixes #222