### PR TITLE
Fix async event loop incompatibility with async-lru 2.2.0

### DIFF
--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -1330,17 +1330,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
             return list(chain.from_iterable(values))
 
-        coro = async_request(self)
-
-        try:
-            return asyncio.run(coro)
-        except RuntimeError:
-            # we use nest_asyncio to support environments where an event loop
-            # is already running, such as in a Jupyter notebook
-            import nest_asyncio
-
-            nest_asyncio.apply()
-            return asyncio.run(coro)
+        return self._run_async(async_request(self))
 
     def _batched_attribute_setter(
         self,
@@ -1368,17 +1358,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
             return list(chain.from_iterable(scoped_keys))
 
-        coro = async_request(self)
-
-        try:
-            return asyncio.run(coro)
-        except RuntimeError:
-            # we use nest_asyncio to support environments where an event loop
-            # is already running, such as in a Jupyter notebook
-            import nest_asyncio
-
-            nest_asyncio.apply()
-            return asyncio.run(coro)
+        return self._run_async(async_request(self))
 
     async def _set_task_status(
         self, tasks: list[ScopedKey], status: TaskStatusEnum
@@ -1620,17 +1600,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
             return pdrs
 
-        coro = async_request(self)
-
-        try:
-            return asyncio.run(coro)
-        except RuntimeError:
-            # we use nest_asyncio to support environments where an event loop
-            # is already running, such as in a Jupyter notebook
-            import nest_asyncio
-
-            nest_asyncio.apply()
-            return asyncio.run(coro)
+        return self._run_async(async_request(self))
 
     def _get_network_results(
         self,


### PR DESCRIPTION
## Summary
- `async-lru` 2.2.0 (released Feb 20) added strict event loop checks that broke `@alru_cache` usage — `asyncio.run()` creates a new loop each time, but `alru_cache` now rejects cross-loop calls
- Replaced all three `asyncio.run()` call sites with `_run_async()`, a new method on `AlchemiscaleBaseClient` that maintains a single shared event loop per class, matching `alru_cache`'s class-level loop tracking
- `nest_asyncio` applied proactively for Jupyter compatibility

## Test plan
- [x] All 138 unit tests pass
- [x] All 376 integration tests pass (including previously-failing `test_cached_pdr` and `test_get_transformation_and_network_results`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)