### PR TITLE
Improve robustness of service termination

### DIFF
--- a/alchemiscale/cli.py
+++ b/alchemiscale/cli.py
@@ -382,6 +382,7 @@ def synchronous(config_file, name, compute_manager_id):
     from alchemiscale.models import Scope
     from alchemiscale.compute.service import SynchronousComputeService
     from alchemiscale.compute.settings import ComputeServiceSettings
+    from alchemiscale.compute.signals import install_stop_handlers
 
     params = yaml.safe_load(config_file)
 
@@ -396,14 +397,8 @@ def synchronous(config_file, name, compute_manager_id):
 
     service = SynchronousComputeService(ComputeServiceSettings(**params_init))
 
-    # add signal handling
-    for signame in {"SIGHUP", "SIGINT", "SIGTERM"}:
-
-        def stop(*args, **kwargs):
-            service.stop()
-            raise KeyboardInterrupt()
-
-        signal.signal(getattr(signal, signame), stop)
+    # install handlers so SIGHUP/SIGINT/SIGTERM stop the service cleanly
+    install_stop_handlers(service)
 
     try:
         service.start(**params_start)

--- a/alchemiscale/cli.py
+++ b/alchemiscale/cli.py
@@ -7,7 +7,6 @@
 import click
 import yaml
 import json
-import signal
 
 from .security.models import (
     CredentialedEntity,
@@ -546,6 +545,7 @@ def strategist(config_file):
     from alchemiscale.models import Scope
     from alchemiscale.strategist.service import StrategistService
     from alchemiscale.strategist.settings import StrategistSettings
+    from alchemiscale.compute.signals import install_stop_handlers
 
     params = yaml.safe_load(config_file)
 
@@ -554,18 +554,12 @@ def strategist(config_file):
 
     service = StrategistService(StrategistSettings(**params))
 
-    # add signal handling
-    for signame in {"SIGHUP", "SIGINT", "SIGTERM"}:
+    # install handlers so SIGHUP/SIGINT/SIGTERM stop the service cleanly.
+    # do *not* raise KeyboardInterrupt --- the strategist's stop() triggers a
+    # ProcessPoolExecutor shutdown that must not be interrupted partway through.
+    install_stop_handlers(service, raise_keyboard_interrupt=False)
 
-        def stop(*args, **kwargs):
-            service.stop()
-
-        signal.signal(getattr(signal, signame), stop)
-
-    try:
-        service.start()
-    except KeyboardInterrupt:
-        pass
+    service.start()
 
 
 @cli.group(help="Subcommands for managing identities")

--- a/alchemiscale/compute/manager.py
+++ b/alchemiscale/compute/manager.py
@@ -5,6 +5,7 @@
 """
 
 from abc import abstractmethod
+from contextlib import contextmanager
 import logging
 import time
 
@@ -77,50 +78,24 @@ class ComputeManager:
     def _deregister(self):
         self.client.deregister(self.compute_manager_id)
 
-    def start(self, max_cycles: int | None = None, steal=False):
-        self.logger.info(f"Starting up compute manager '{self.settings.name}'")
+    @contextmanager
+    def _registered(self, steal=False):
+        """Register this compute manager for the lifetime of the context.
+
+        This guarantees that if anything interrupts startup after registration,
+        including int_sleep.clear(), the manager is still deregistered.
+        """
         registered = False
 
         try:
             self._register(steal=steal)
             registered = True
 
-            self.logger.info(f"Registered compute manager '{self.compute_manager_id}'")
+            self.logger.info(
+                f"Registered compute manager '{self.compute_manager_id}'"
+            )
 
-            self._stop = False
-            self.int_sleep.clear()
-
-            count = 0
-            self.logger.info("Starting main loop")
-
-            while self.cycle():
-                count += 1
-
-                if max_cycles and count >= max_cycles:
-                    self.logger.info("Reached maximum number of cycles")
-                    break
-
-                self.logger.info(f"Sleeping for {self.settings.sleep_interval} seconds")
-                self.int_sleep(self.settings.sleep_interval)
-
-        except SleepInterrupted:
-            self.logger.info("Compute manager stopping.")
-
-        except KeyboardInterrupt:
-            self.logger.info("Caught SIGINT/Keyboard interrupt.")
-
-        except Exception as e:
-            self.logger.error(f"Unknown exception raised: '{str(e)}'")
-
-            if registered:
-                self.logger.info("Updating manager status to 'ERROR'")
-                self.client.update_status(
-                    self.compute_manager_id,
-                    ComputeManagerStatus.ERROR,
-                    detail=repr(e),
-                )
-
-            raise
+            yield
 
         finally:
             if registered:
@@ -132,8 +107,54 @@ class ComputeManager:
                 if heartbeat_thread is not None:
                     heartbeat_thread.join(timeout=5)
 
+                    if heartbeat_thread.is_alive():
+                        self.logger.warning(
+                            "Heartbeat thread did not stop within 5 seconds"
+                        )
+
                 self._deregister()
                 self.logger.info("Deregistration successful")
+
+    def start(self, max_cycles: int | None = None, steal=False):
+        self.logger.info(f"Starting up compute manager '{self.settings.name}'")
+
+        with self._registered(steal=steal):
+            try:
+                self._stop = False
+                self.int_sleep.clear()
+
+                count = 0
+                self.logger.info("Starting main loop")
+
+                while self.cycle():
+                    count += 1
+
+                    if max_cycles and count >= max_cycles:
+                        self.logger.info("Reached maximum number of cycles")
+                        break
+
+                    self.logger.info(
+                        f"Sleeping for {self.settings.sleep_interval} seconds"
+                    )
+                    self.int_sleep(self.settings.sleep_interval)
+
+            except SleepInterrupted:
+                self.logger.info("Compute manager stopping.")
+
+            except KeyboardInterrupt:
+                self.logger.info("Caught SIGINT/Keyboard interrupt.")
+
+            except Exception as e:
+                self.logger.error(f"Unknown exception raised: '{str(e)}'")
+                self.logger.info("Updating manager status to 'ERROR'")
+
+                self.client.update_status(
+                    self.compute_manager_id,
+                    ComputeManagerStatus.ERROR,
+                    detail=repr(e),
+                )
+
+                raise
 
     @abstractmethod
     def create_compute_services(self, data: dict, target: int) -> int:

--- a/alchemiscale/compute/manager.py
+++ b/alchemiscale/compute/manager.py
@@ -91,9 +91,7 @@ class ComputeManager:
             self._register(steal=steal)
             registered = True
 
-            self.logger.info(
-                f"Registered compute manager '{self.compute_manager_id}'"
-            )
+            self.logger.info(f"Registered compute manager '{self.compute_manager_id}'")
 
             yield
 

--- a/alchemiscale/compute/manager.py
+++ b/alchemiscale/compute/manager.py
@@ -17,6 +17,7 @@ from .client import (
     AlchemiscaleComputeManagerClient,
     AlchemiscaleComputeManagerClientError,
 )
+from .service import InterruptableSleep, SleepInterrupted
 from .settings import ComputeManagerSettings, ComputeServiceSettings
 
 
@@ -44,6 +45,7 @@ class ComputeManager:
         )
 
         self._stop = False
+        self.int_sleep = InterruptableSleep()
 
         logger = logging.getLogger("AlchemiscaleComputeManager")
         logger.setLevel(self.settings.loglevel)
@@ -80,6 +82,7 @@ class ComputeManager:
         self._register(steal=steal)
         self.logger.info(f"Registered compute manager '{self.compute_manager_id}'")
         self._stop = False
+        self.int_sleep.clear()
         try:
             count = 0
             self.logger.info("Starting main loop")
@@ -89,7 +92,9 @@ class ComputeManager:
                     self.logger.info("Reached maximum number of cycles")
                     break
                 self.logger.info(f"Sleeping for {self.settings.sleep_interval} seconds")
-                time.sleep(self.settings.sleep_interval)
+                self.int_sleep(self.settings.sleep_interval)
+        except SleepInterrupted:
+            self.logger.info("Compute manager stopping.")
         except Exception as e:
             self.logger.error(f"Unknown exception raised: '{str(e)}'")
             self.logger.info(f"Updating manager status to 'ERROR'")
@@ -113,6 +118,7 @@ class ComputeManager:
         raise NotImplementedError
 
     def stop(self):
+        self.int_sleep.interrupt()
         self._stop = True
 
     def cycle(self) -> bool:

--- a/alchemiscale/compute/manager.py
+++ b/alchemiscale/compute/manager.py
@@ -79,35 +79,61 @@ class ComputeManager:
 
     def start(self, max_cycles: int | None = None, steal=False):
         self.logger.info(f"Starting up compute manager '{self.settings.name}'")
-        self._register(steal=steal)
-        self.logger.info(f"Registered compute manager '{self.compute_manager_id}'")
-        self._stop = False
-        self.int_sleep.clear()
+        registered = False
+
         try:
+            self._register(steal=steal)
+            registered = True
+
+            self.logger.info(f"Registered compute manager '{self.compute_manager_id}'")
+
+            self._stop = False
+            self.int_sleep.clear()
+
             count = 0
             self.logger.info("Starting main loop")
+
             while self.cycle():
                 count += 1
+
                 if max_cycles and count >= max_cycles:
                     self.logger.info("Reached maximum number of cycles")
                     break
+
                 self.logger.info(f"Sleeping for {self.settings.sleep_interval} seconds")
                 self.int_sleep(self.settings.sleep_interval)
+
         except SleepInterrupted:
             self.logger.info("Compute manager stopping.")
-        except Exception as e:
-            self.logger.error(f"Unknown exception raised: '{str(e)}'")
-            self.logger.info(f"Updating manager status to 'ERROR'")
-            self.client.update_status(
-                self.compute_manager_id, ComputeManagerStatus.ERROR, detail=repr(e)
-            )
-            raise e
+
         except KeyboardInterrupt:
             self.logger.info("Caught SIGINT/Keyboard interrupt.")
+
+        except Exception as e:
+            self.logger.error(f"Unknown exception raised: '{str(e)}'")
+
+            if registered:
+                self.logger.info("Updating manager status to 'ERROR'")
+                self.client.update_status(
+                    self.compute_manager_id,
+                    ComputeManagerStatus.ERROR,
+                    detail=repr(e),
+                )
+
+            raise
+
         finally:
-            self.logger.info(f"Deregistering '{self.compute_manager_id}'")
-            self._deregister()
-            self.logger.info(f"Deregistration successful")
+            if registered:
+                self.logger.info(f"Deregistering '{self.compute_manager_id}'")
+
+                self.stop()
+
+                heartbeat_thread = getattr(self, "heartbeat_thread", None)
+                if heartbeat_thread is not None:
+                    heartbeat_thread.join(timeout=5)
+
+                self._deregister()
+                self.logger.info("Deregistration successful")
 
     @abstractmethod
     def create_compute_services(self, data: dict, target: int) -> int:

--- a/alchemiscale/compute/manager.py
+++ b/alchemiscale/compute/manager.py
@@ -17,8 +17,8 @@ from .client import (
     AlchemiscaleComputeManagerClient,
     AlchemiscaleComputeManagerClientError,
 )
-from .service import InterruptableSleep, SleepInterrupted
 from .settings import ComputeManagerSettings, ComputeServiceSettings
+from ..sleep import InterruptableSleep, SleepInterrupted
 
 
 class ComputeManager:

--- a/alchemiscale/compute/manager.py
+++ b/alchemiscale/compute/manager.py
@@ -79,7 +79,7 @@ class ComputeManager:
         self.client.deregister(self.compute_manager_id)
 
     @contextmanager
-    def _registered(self, steal=False):
+    def _running(self, steal=False):
         """Register this compute manager for the lifetime of the context.
 
         This guarantees that if anything interrupts startup after registration,
@@ -93,22 +93,17 @@ class ComputeManager:
 
             self.logger.info(f"Registered compute manager '{self.compute_manager_id}'")
 
+            self._stop = False
+            self.int_sleep.clear()
+
             yield
 
         finally:
             if registered:
                 self.logger.info(f"Deregistering '{self.compute_manager_id}'")
 
+                # kept here in case we add additional cleanup to stop later, such as other threads
                 self.stop()
-
-                heartbeat_thread = getattr(self, "heartbeat_thread", None)
-                if heartbeat_thread is not None:
-                    heartbeat_thread.join(timeout=5)
-
-                    if heartbeat_thread.is_alive():
-                        self.logger.warning(
-                            "Heartbeat thread did not stop within 5 seconds"
-                        )
 
                 self._deregister()
                 self.logger.info("Deregistration successful")
@@ -116,11 +111,8 @@ class ComputeManager:
     def start(self, max_cycles: int | None = None, steal=False):
         self.logger.info(f"Starting up compute manager '{self.settings.name}'")
 
-        with self._registered(steal=steal):
+        with self._running(steal=steal):
             try:
-                self._stop = False
-                self.int_sleep.clear()
-
                 count = 0
                 self.logger.info("Starting main loop")
 

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -20,43 +20,8 @@ from .settings import ComputeServiceSettings
 from ..storage.models import ComputeServiceID
 from ..models import Scope, ScopedKey
 
-
-class SleepInterrupted(BaseException):
-    """
-    Exception class used to signal that an InterruptableSleep was interrupted
-
-    This (like KeyboardInterrupt) derives from BaseException to prevent
-    it from being handled with "except Exception".
-    """
-
-    pass
-
-
-class InterruptableSleep:
-    """
-    A class for sleeping, but interruptable
-
-    This class uses threading Events to wake up from a sleep before the entire sleep
-    duration has run. If the sleep is interrupted, then an SleepInterrupted exception is raised.
-
-    This class is a functor: call an instance with a delay in seconds to sleep for that
-    duration (e.g. ``int_sleep(30)``), and call :meth:`interrupt` from another thread to
-    wake it early.
-    """
-
-    def __init__(self):
-        self._event = threading.Event()
-
-    def __call__(self, delay: float):
-        interrupted = self._event.wait(delay)
-        if interrupted:
-            raise SleepInterrupted()
-
-    def interrupt(self):
-        self._event.set()
-
-    def clear(self):
-        self._event.clear()
+# moved to alchemiscale.sleep; re-exported here for backwards compatibility
+from ..sleep import InterruptableSleep, SleepInterrupted
 
 
 class SynchronousComputeService:

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -112,11 +112,12 @@ class SynchronousComputeService:
 
     def heartbeat(self):
         """Start up the heartbeat, sleeping for `self.heartbeat_interval`"""
-        while True:
-            if self._stop:
-                break
+        while not self._stop:
             self.beat()
-            time.sleep(self.heartbeat_interval)
+            try:
+                self.int_sleep(self.heartbeat_interval)
+            except SleepInterrupted:
+                break
 
     def claim_tasks(self, count=1) -> list[ScopedKey | None]:
         """Get a Task to execute from compute API.

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -122,9 +122,23 @@ class SynchronousComputeService:
         self.logger.debug("Updated heartbeat")
 
     def heartbeat(self):
-        """Start up the heartbeat, sleeping for `self.heartbeat_interval`"""
+        """Start up the heartbeat, sleeping for `self.heartbeat_interval`.
+
+        A failing ``beat()`` is logged and the loop continues; the thread
+        only exits on ``stop()`` (via ``SleepInterrupted``) or process
+        teardown. The compute API exposes its own retry policy on the
+        underlying client call, but if those retries are ever exhausted ---
+        e.g. a sustained outage or auth-token expiry --- a raised exception
+        here would otherwise silently kill the heartbeat thread while the
+        main loop kept processing tasks. Swallow per-beat failures so a
+        transient problem doesn't deregister the service from the API's
+        point of view.
+        """
         while not self._stop:
-            self.beat()
+            try:
+                self.beat()
+            except Exception:
+                self.logger.exception("Heartbeat failed; will retry next interval")
             try:
                 self.int_sleep(self.heartbeat_interval)
             except SleepInterrupted:

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -4,6 +4,7 @@
 
 """
 
+from contextlib import contextmanager
 import gc
 import time
 import logging
@@ -309,6 +310,65 @@ class SynchronousComputeService:
         self._check_max_tasks(max_tasks)
         self._check_max_time(max_time)
 
+    def _start_heartbeat(self):
+        self.heartbeat_thread = threading.Thread(
+            target=self.heartbeat,
+            daemon=True,
+        )
+        self.heartbeat_thread.start()
+
+    def _stop_heartbeat(self, timeout=5):
+        self.stop()
+
+        heartbeat_thread = getattr(self, "heartbeat_thread", None)
+        if heartbeat_thread is not None:
+            heartbeat_thread.join(timeout=timeout)
+
+            if heartbeat_thread.is_alive():
+                self.logger.warning(
+                    "Heartbeat thread did not stop within %s seconds",
+                    timeout,
+                )
+
+    @contextmanager
+    def _running(self):
+        """Register the service and run heartbeat for the lifetime of the context."""
+        registered = False
+        heartbeat_started = False
+
+        try:
+            self._register()
+            registered = True
+
+            self.logger.info(
+                "Registered service with registration '%s'",
+                str(self.compute_service_id),
+            )
+
+            self._stop = False
+            self.int_sleep.clear()
+
+            self._start_heartbeat()
+            heartbeat_started = True
+
+            yield
+
+        finally:
+            if heartbeat_started:
+                self._stop_heartbeat(timeout=5)
+            else:
+                # If interrupted after registration but before heartbeat startup,
+                # still request a clean stop.
+                self.stop()
+
+            if registered:
+                self.logger.info(
+                    "Deregistering service with registration '%s'",
+                    str(self.compute_service_id),
+                )
+                self._deregister()
+                self.logger.info("Deregistration successful")
+
     def start(self, max_tasks: int | None = None, max_time: int | None = None):
         """Start the service.
 
@@ -326,52 +386,28 @@ class SynchronousComputeService:
             If `None`, the service will have no time limit.
 
         """
-        self._stop = False
-        self.int_sleep.clear()
-
-        # add ComputeServiceRegistration
         self.logger.info("Starting up service '%s'", self.name)
-        self._register()
-        self.logger.info(
-            "Registered service with registration '%s'", str(self.compute_service_id)
-        )
 
-        # start up heartbeat thread
-        self.heartbeat_thread = threading.Thread(target=self.heartbeat, daemon=True)
-        self.heartbeat_thread.start()
+        with self._running():
+            try:
+                self._tasks_counter = 0
+                self._start_time = time.time()
 
-        # stop conditions will use these
-        self._tasks_counter = 0
-        self._start_time = time.time()
+                self.logger.info("Starting main loop")
 
-        try:
-            self.logger.info("Starting main loop")
-            while not self._stop:
-                # check that heartbeat is still alive; if not, resurrect it
-                if not self.heartbeat_thread.is_alive():
-                    self.heartbeat_thread = threading.Thread(
-                        target=self.heartbeat, daemon=True
-                    )
-                    self.heartbeat_thread.start()
+                while not self._stop:
+                    self.cycle(max_tasks=max_tasks, max_time=max_time)
+                    gc.collect()
 
-                # perform main loop cycle
-                self.cycle(max_tasks, max_time)
+            except SleepInterrupted:
+                self.logger.info("Service stopping.")
 
-                # force a garbage collection to avoid consuming too much memory
-                gc.collect()
-        except KeyboardInterrupt:
-            self.logger.info("Caught SIGINT/Keyboard interrupt.")
-        except SleepInterrupted:
-            self.logger.info("Service stopping.")
-        finally:
-            # remove ComputeServiceRegistration, drop all claims
-            self.stop()
-            self.heartbeat_thread.join(timeout=5)
-            self._deregister()
-            self.logger.info(
-                "Deregistered service with registration '%s'",
-                str(self.compute_service_id),
-            )
+            except KeyboardInterrupt:
+                self.logger.info("Caught SIGINT/Keyboard interrupt.")
+
+            except Exception:
+                self.logger.exception("Unknown exception raised")
+                raise
 
     def stop(self):
         self.int_sleep.interrupt()

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -5,7 +5,6 @@
 """
 
 import gc
-import sched
 import time
 import logging
 from uuid import uuid4
@@ -40,8 +39,9 @@ class InterruptableSleep:
     This class uses threading Events to wake up from a sleep before the entire sleep
     duration has run. If the sleep is interrupted, then an SleepInterrupted exception is raised.
 
-    This class is a functor, so an instance can be passed as the delay function to a python
-    sched.scheduler
+    This class is a functor: call an instance with a delay in seconds to sleep for that
+    duration (e.g. ``int_sleep(30)``), and call :meth:`interrupt` from another thread to
+    wake it early.
     """
 
     def __init__(self):
@@ -104,8 +104,6 @@ class SynchronousComputeService:
         self.scratch_basedir = Path(self.settings.scratch_basedir).absolute()
         self.scratch_basedir.mkdir(exist_ok=True)
         self.keep_scratch = self.settings.keep_scratch
-
-        self.scheduler = sched.scheduler(time.monotonic, time.sleep)
 
         self.compute_service_id = ComputeServiceID.new_from_name(self.name)
 
@@ -302,7 +300,7 @@ class SynchronousComputeService:
 
         if tasks is None:
             self.logger.info("No tasks claimed. Compute API denied request.")
-            time.sleep(self.deep_sleep_interval)
+            self.int_sleep(self.deep_sleep_interval)
             return
 
         self.logger.info("Claimed %d tasks", len([t for t in tasks if t is not None]))
@@ -312,7 +310,7 @@ class SynchronousComputeService:
             self.logger.info(
                 "No tasks claimed; sleeping for %d seconds", self.sleep_interval
             )
-            time.sleep(self.sleep_interval)
+            self.int_sleep(self.sleep_interval)
             return
 
         # otherwise, process tasks
@@ -354,6 +352,7 @@ class SynchronousComputeService:
 
         """
         self._stop = False
+        self.int_sleep.clear()
 
         # add ComputeServiceRegistration
         self.logger.info("Starting up service '%s'", self.name)
@@ -411,7 +410,6 @@ class AsynchronousComputeService(SynchronousComputeService):
     """
 
     def __init__(self, api_url):
-        self.scheduler = sched.scheduler(time.monotonic, time.sleep)
         # self.loop = asyncio.get_event_loop()
 
         self._stop = False

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -72,6 +72,12 @@ class SynchronousComputeService:
 
         self.compute_service_id = ComputeServiceID.new_from_name(self.name)
 
+        # shared between the main loop and the heartbeat thread; both wake
+        # on a single ``stop()`` (which calls ``int_sleep.interrupt()``).
+        # If you split these into separate functors, be sure to interrupt
+        # both from ``stop()`` --- otherwise the heartbeat thread stays
+        # alive (and the worker stays multi-threaded) until its sleep
+        # naturally expires.
         self.int_sleep = InterruptableSleep()
 
         self._stop = False

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -365,6 +365,8 @@ class SynchronousComputeService:
             self.logger.info("Service stopping.")
         finally:
             # remove ComputeServiceRegistration, drop all claims
+            self.stop()
+            self.heartbeat_thread.join(timeout=5)
             self._deregister()
             self.logger.info(
                 "Deregistered service with registration '%s'",

--- a/alchemiscale/compute/signals.py
+++ b/alchemiscale/compute/signals.py
@@ -1,0 +1,63 @@
+"""
+:mod:`alchemiscale.compute.signals` --- graceful shutdown signal handling
+==========================================================================
+
+Helpers for wiring OS signals to the ``stop()`` method of a long-running
+service or compute manager.
+
+Signal disposition is process-global and :func:`signal.signal` may only be
+called from the main thread, so installing handlers is the responsibility of
+the *entry point* (a CLI command) that owns the process --- not of the library
+classes themselves. This module provides that wiring as a single reusable call
+so each entry point does not reimplement (and risk forgetting) it.
+
+"""
+
+import signal
+from typing import Protocol
+
+
+class Stoppable(Protocol):
+    """Anything exposing an idempotent ``stop()`` method."""
+
+    def stop(self) -> None: ...
+
+
+#: Signals that, by default, trigger a graceful shutdown.
+DEFAULT_STOP_SIGNALS: tuple[str, ...] = ("SIGHUP", "SIGINT", "SIGTERM")
+
+
+def install_stop_handlers(
+    stoppable: Stoppable,
+    signal_names: tuple[str, ...] = DEFAULT_STOP_SIGNALS,
+) -> None:
+    """Install signal handlers that gracefully stop ``stoppable``.
+
+    For each name in ``signal_names``, registers a handler that calls
+    ``stoppable.stop()`` and then raises :class:`KeyboardInterrupt`. The
+    ``stop()`` call tells the object's main loop to wind down (waking any
+    interruptible sleep), while the raised :class:`KeyboardInterrupt` unwinds
+    the main thread so the loop's shutdown/deregistration logic runs promptly.
+
+    Must be called from the main thread; :func:`signal.signal` raises
+    otherwise. Signal names not present on the current platform are skipped.
+
+    Parameters
+    ----------
+    stoppable
+        An object exposing a ``stop()`` method, e.g. a
+        :class:`~alchemiscale.compute.service.SynchronousComputeService` or a
+        :class:`~alchemiscale.compute.manager.ComputeManager`.
+    signal_names
+        Names of the signals to handle; defaults to
+        :data:`DEFAULT_STOP_SIGNALS`.
+    """
+
+    def handler(signum, frame):
+        stoppable.stop()
+        raise KeyboardInterrupt()
+
+    for name in signal_names:
+        signum = getattr(signal, name, None)
+        if signum is not None:
+            signal.signal(signum, handler)

--- a/alchemiscale/compute/signals.py
+++ b/alchemiscale/compute/signals.py
@@ -30,14 +30,17 @@ DEFAULT_STOP_SIGNALS: tuple[str, ...] = ("SIGHUP", "SIGINT", "SIGTERM")
 def install_stop_handlers(
     stoppable: Stoppable,
     signal_names: tuple[str, ...] = DEFAULT_STOP_SIGNALS,
+    *,
+    raise_keyboard_interrupt: bool = True,
 ) -> None:
     """Install signal handlers that gracefully stop ``stoppable``.
 
     For each name in ``signal_names``, registers a handler that calls
-    ``stoppable.stop()`` and then raises :class:`KeyboardInterrupt`. The
-    ``stop()`` call tells the object's main loop to wind down (waking any
-    interruptible sleep), while the raised :class:`KeyboardInterrupt` unwinds
-    the main thread so the loop's shutdown/deregistration logic runs promptly.
+    ``stoppable.stop()`` and (by default) then raises
+    :class:`KeyboardInterrupt`. The ``stop()`` call tells the object's main
+    loop to wind down (waking any interruptible sleep), while the raised
+    :class:`KeyboardInterrupt` unwinds the main thread so the loop's
+    shutdown/deregistration logic runs promptly.
 
     Must be called from the main thread; :func:`signal.signal` raises
     otherwise. Signal names not present on the current platform are skipped.
@@ -51,11 +54,20 @@ def install_stop_handlers(
     signal_names
         Names of the signals to handle; defaults to
         :data:`DEFAULT_STOP_SIGNALS`.
+    raise_keyboard_interrupt
+        If ``True`` (default), the handler also raises
+        :class:`KeyboardInterrupt` after calling ``stop()``. Set ``False``
+        when the caller relies on cooperative shutdown only and a
+        :class:`KeyboardInterrupt` would interfere with teardown --- e.g. a
+        service whose ``stop()`` triggers a
+        :class:`~concurrent.futures.ProcessPoolExecutor` shutdown that must
+        not be interrupted partway through.
     """
 
     def handler(signum, frame):
         stoppable.stop()
-        raise KeyboardInterrupt()
+        if raise_keyboard_interrupt:
+            raise KeyboardInterrupt()
 
     for name in signal_names:
         signum = getattr(signal, name, None)

--- a/alchemiscale/sleep.py
+++ b/alchemiscale/sleep.py
@@ -1,0 +1,50 @@
+"""
+:mod:`alchemiscale.sleep` --- interruptible sleep primitive
+===========================================================
+
+A small, dependency-free sleep primitive shared by the long-running services
+(compute service, compute manager, strategist) so that a blocking sleep between
+work cycles can be woken early from another thread (e.g. a signal handler
+calling ``stop()``).
+
+"""
+
+import threading
+
+
+class SleepInterrupted(BaseException):
+    """
+    Exception class used to signal that an InterruptableSleep was interrupted
+
+    This (like KeyboardInterrupt) derives from BaseException to prevent
+    it from being handled with "except Exception".
+    """
+
+    pass
+
+
+class InterruptableSleep:
+    """
+    A class for sleeping, but interruptable
+
+    This class uses threading Events to wake up from a sleep before the entire sleep
+    duration has run. If the sleep is interrupted, then an SleepInterrupted exception is raised.
+
+    This class is a functor: call an instance with a delay in seconds to sleep for that
+    duration (e.g. ``int_sleep(30)``), and call :meth:`interrupt` from another thread to
+    wake it early.
+    """
+
+    def __init__(self):
+        self._event = threading.Event()
+
+    def __call__(self, delay: float):
+        interrupted = self._event.wait(delay)
+        if interrupted:
+            raise SleepInterrupted()
+
+    def interrupt(self):
+        self._event.set()
+
+    def clear(self):
+        self._event.clear()

--- a/alchemiscale/strategist/service.py
+++ b/alchemiscale/strategist/service.py
@@ -35,6 +35,7 @@ from ..storage.models import (
 )
 from ..settings import Neo4jStoreSettings, S3ObjectStoreSettings
 from ..compression import compress_keyed_chain_zstd, decompress_gufe_zstd, json_to_gufe
+from ..sleep import InterruptableSleep, SleepInterrupted
 from .settings import StrategistSettings
 
 
@@ -123,6 +124,7 @@ class StrategistService:
             self._cache = None
 
         self._stop = False
+        self.int_sleep = InterruptableSleep()
 
         # logging
         self.logger = logging.getLogger("AlchemiscaleStrategistService")
@@ -679,6 +681,7 @@ class StrategistService:
         """Start the Strategist service."""
 
         self._stop = False
+        self.int_sleep.clear()
         self.logger.info("Starting Strategist service")
 
         try:
@@ -700,8 +703,10 @@ class StrategistService:
 
                 if remaining_sleep > 0:
                     self.logger.debug(f"Sleeping for {remaining_sleep:.1f} seconds")
-                    time.sleep(remaining_sleep)
+                    self.int_sleep(remaining_sleep)
 
+        except SleepInterrupted:
+            self.logger.info("Sleep interrupted; stopping Strategist service")
         except KeyboardInterrupt:
             self.logger.info("Received interrupt signal")
         finally:
@@ -710,6 +715,7 @@ class StrategistService:
 
     def stop(self):
         """Stop the strategist service."""
+        self.int_sleep.interrupt()
         self._stop = True
 
     def close(self):

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -310,3 +310,44 @@ class TestComputeManager:
         # the manager should have deregistered itself on the way out
         query = """MATCH (cmr:ComputeManagerRegistration) RETURN cmr"""
         assert not n4js_preloaded.execute_query(query).records
+
+    def test_manager_start_deregisters_if_interrupted_during_startup_setup(
+        self,
+        n4js_preloaded,
+        manager: LocalTestingComputeManager,
+        monkeypatch,
+    ):
+        """start() should deregister even if interrupted after registration.
+
+        This simulates a signal/KeyboardInterrupt landing after the manager has
+        registered, but before start() reaches the try/finally that normally
+        performs deregistration.
+        """
+        interrupted = False
+
+        def interrupt_after_registration():
+            nonlocal interrupted
+            interrupted = True
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(manager.int_sleep, "clear", interrupt_after_registration)
+
+        query = """MATCH (cmr:ComputeManagerRegistration) RETURN cmr"""
+
+        try:
+            try:
+                manager.start(max_cycles=1)
+            except KeyboardInterrupt:
+                pass
+
+            assert interrupted
+
+            # This should fail without the fix: the manager registered, then the
+            # simulated interrupt skipped the finally block, leaving an orphaned
+            # ComputeManagerRegistration.
+            assert not n4js_preloaded.execute_query(query).records
+
+        finally:
+            # Keep the failing test from poisoning later tests.
+            if n4js_preloaded.execute_query(query).records:
+                manager._deregister()

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -247,6 +247,9 @@ class TestComputeManager:
 
         assert "Received shutdown message" in caplog.text
 
+    @pytest.mark.skip(
+        reason="bisect: confirmed culprit of CI hang on 3.11/3.13 (PR #503); fork-from-thread interaction"
+    )
     def test_manager_interruptible_sleep(
         self,
         n4js_preloaded,

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -1,6 +1,7 @@
 import datetime
 from uuid import uuid4
 import logging
+import threading
 import time
 import sys
 import signal
@@ -245,3 +246,43 @@ class TestComputeManager:
         manager.cycle()
 
         assert "Received shutdown message" in caplog.text
+
+    def test_manager_interruptible_sleep(
+        self,
+        n4js_preloaded,
+        manager: LocalTestingComputeManager,
+        caplog,
+    ):
+        caplog.set_level(logging.INFO, logger=manager.logger.name)
+
+        # use a long sleep interval; if the sleep were *not* interruptible,
+        # stop() would not take effect until this elapsed and this test would
+        # time out waiting on the thread to join
+        manager.settings.sleep_interval = 300
+
+        thread = threading.Thread(target=manager.start)
+        thread.start()
+
+        try:
+            # wait until the manager has entered its (interruptible) sleep
+            deadline = time.monotonic() + 30
+            while "Sleeping for" not in caplog.text:
+                assert time.monotonic() < deadline, "manager never reached its sleep"
+                time.sleep(0.05)
+
+            # interrupting the sleep should let start() return promptly rather
+            # than blocking for the full sleep_interval
+            interrupt_time = time.monotonic()
+            manager.stop()
+            thread.join(timeout=30)
+
+            assert not thread.is_alive()
+            assert (time.monotonic() - interrupt_time) < 30
+            assert "Compute manager stopping." in caplog.text
+        finally:
+            manager.stop()
+            thread.join(timeout=30)
+
+        # the manager should have deregistered itself on the way out
+        query = """MATCH (cmr:ComputeManagerRegistration) RETURN cmr"""
+        assert not n4js_preloaded.execute_query(query).records

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -247,15 +247,19 @@ class TestComputeManager:
 
         assert "Received shutdown message" in caplog.text
 
-    @pytest.mark.skip(
-        reason="bisect: confirmed culprit of CI hang on 3.11/3.13 (PR #503); fork-from-thread interaction"
-    )
     def test_manager_interruptible_sleep(
         self,
-        n4js_preloaded,
+        n4js_fresh,
         manager: LocalTestingComputeManager,
         caplog,
     ):
+        # use n4js_fresh (no preloaded tasks) rather than n4js_preloaded so
+        # cycle() returns without calling create_compute_services. The latter
+        # forks a Process from this test's worker, which is already
+        # multi-threaded (the manager.start thread below) — and fork from a
+        # multi-threaded Python process inherits other threads' locks as held,
+        # deadlocking the child. That deadlock hung the xdist worker on 3.11
+        # and 3.13 (3.12 happens to dodge it). See PR #503 discussion.
         caplog.set_level(logging.INFO, logger=manager.logger.name)
 
         # use a long sleep interval; if the sleep were *not* interruptible,
@@ -288,4 +292,4 @@ class TestComputeManager:
 
         # the manager should have deregistered itself on the way out
         query = """MATCH (cmr:ComputeManagerRegistration) RETURN cmr"""
-        assert not n4js_preloaded.execute_query(query).records
+        assert not n4js_fresh.execute_query(query).records

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -249,18 +249,22 @@ class TestComputeManager:
 
     def test_manager_interruptible_sleep(
         self,
-        n4js_fresh,
+        n4js_preloaded,
         manager: LocalTestingComputeManager,
         caplog,
     ):
-        # use n4js_fresh (no preloaded tasks) rather than n4js_preloaded so
-        # cycle() returns without calling create_compute_services. The latter
-        # forks a Process from this test's worker, which is already
-        # multi-threaded (the manager.start thread below) — and fork from a
-        # multi-threaded Python process inherits other threads' locks as held,
-        # deadlocking the child. That deadlock hung the xdist worker on 3.11
-        # and 3.13 (3.12 happens to dodge it). See PR #503 discussion.
         caplog.set_level(logging.INFO, logger=manager.logger.name)
+
+        # suppress the subprocess spawn. The default create_compute_services
+        # forks a multiprocessing.Process; combined with the background
+        # thread below, that makes this test fork from a multi-threaded
+        # parent. POSIX fork only carries the calling thread, so locks held
+        # by other threads (logging, requests pools, ...) are inherited as
+        # held-with-no-owner in the child, which then deadlocks. That hung
+        # the xdist worker on 3.11/3.13 (3.12 happens to miss it). The test
+        # is about stop() interrupting the sleep, not about spawning, so
+        # we cut the spawn path here. See PR #503 discussion.
+        manager.create_compute_services = lambda data: 0
 
         # use a long sleep interval; if the sleep were *not* interruptible,
         # stop() would not take effect until this elapsed and this test would
@@ -292,4 +296,4 @@ class TestComputeManager:
 
         # the manager should have deregistered itself on the way out
         query = """MATCH (cmr:ComputeManagerRegistration) RETURN cmr"""
-        assert not n4js_fresh.execute_query(query).records
+        assert not n4js_preloaded.execute_query(query).records

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -247,9 +247,6 @@ class TestComputeManager:
 
         assert "Received shutdown message" in caplog.text
 
-    @pytest.mark.skip(
-        reason="bisect: temporarily skipped to isolate CI hang on 3.11/3.13 (PR #503)"
-    )
     def test_manager_interruptible_sleep(
         self,
         n4js_preloaded,

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -252,6 +252,7 @@ class TestComputeManager:
         n4js_preloaded,
         manager: LocalTestingComputeManager,
         caplog,
+        monkeypatch,
     ):
         caplog.set_level(logging.INFO, logger=manager.logger.name)
 
@@ -264,7 +265,7 @@ class TestComputeManager:
         # the xdist worker on 3.11/3.13 (3.12 happens to miss it). The test
         # is about stop() interrupting the sleep, not about spawning, so
         # we cut the spawn path here. See PR #503 discussion.
-        manager.create_compute_services = lambda data: 0
+        monkeypatch.setattr(manager, "create_compute_services", lambda data: 0)
 
         # use a long sleep interval; if the sleep were *not* interruptible,
         # stop() would not take effect until this elapsed and this test would

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -247,6 +247,9 @@ class TestComputeManager:
 
         assert "Received shutdown message" in caplog.text
 
+    @pytest.mark.skip(
+        reason="bisect: temporarily skipped to isolate CI hang on 3.11/3.13 (PR #503)"
+    )
     def test_manager_interruptible_sleep(
         self,
         n4js_preloaded,

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -275,7 +275,9 @@ class TestComputeManager:
         # the xdist worker on 3.11/3.13 (3.12 happens to miss it). The test
         # is about stop() interrupting the sleep, not about spawning, so
         # we cut the spawn path here. See PR #503 discussion.
-        monkeypatch.setattr(manager, "create_compute_services", lambda data: 0)
+        # signature is (data, target) since #502 moved autoscaling sizing
+        # into ComputeManager; the no-op still returns 0 (no services created)
+        monkeypatch.setattr(manager, "create_compute_services", lambda data, target: 0)
 
         # use a long sleep interval; if the sleep were *not* interruptible,
         # stop() would not take effect until this elapsed and this test would

--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import time
 import os
@@ -225,6 +226,65 @@ class TestSynchronousComputeService:
 
         results = n4js.execute_query(q)
         assert results.records
+
+    def test_start_interruptible_sleep(
+        self, n4js_preloaded, compute_client, tmpdir, caplog
+    ):
+        n4js: Neo4jStore = n4js_preloaded
+
+        # a service whose sleep interval is long enough that, were the sleep
+        # *not* interruptible, stop() would block until it elapsed and this
+        # test would time out joining the thread
+        with tmpdir.as_cwd():
+            service = SynchronousComputeService(
+                ComputeServiceSettings(
+                    api_url=compute_client.api_url,
+                    identifier=compute_client.identifier,
+                    key=compute_client.key,
+                    name="test_compute_service_interruptible",
+                    shared_basedir=Path("shared").absolute(),
+                    scratch_basedir=Path("scratch").absolute(),
+                    heartbeat_interval=300,
+                    sleep_interval=300,
+                    deep_sleep_interval=300,
+                )
+            )
+
+        # force the "no tasks claimed; sleeping" branch every cycle so the
+        # service parks itself in an interruptible sleep rather than executing
+        service.claim_tasks = lambda count=1: [None]
+
+        caplog.set_level(logging.INFO, logger=service.logger.name)
+
+        service_thread = threading.Thread(target=service.start, daemon=True)
+        service_thread.start()
+
+        try:
+            # wait until the service has actually entered its sleep
+            deadline = time.monotonic() + 30
+            while "No tasks claimed; sleeping" not in caplog.text:
+                assert time.monotonic() < deadline, "service never reached its sleep"
+                time.sleep(0.05)
+
+            # interrupting the sleep should let start() return promptly rather
+            # than blocking for the full sleep_interval
+            interrupt_time = time.monotonic()
+            service.stop()
+            service_thread.join(timeout=30)
+
+            assert not service_thread.is_alive()
+            assert (time.monotonic() - interrupt_time) < 30
+            assert "Service stopping." in caplog.text
+        finally:
+            service.stop()
+            service_thread.join(timeout=30)
+
+        # the service should have deregistered itself on the way out
+        q = f"""
+        match (csreg:ComputeServiceRegistration {{identifier: '{service.compute_service_id}'}})
+        return csreg
+        """
+        assert not n4js.execute_query(q).records
 
     @pytest.mark.xfail(raises=NotImplementedError)
     def test_stop(self):

--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -63,6 +63,46 @@ class TestSynchronousComputeService:
         time.sleep(2)
         assert not heartbeat_thread.is_alive()
 
+    def test_heartbeat_survives_beat_exception(self, service, monkeypatch, caplog):
+        """A failing beat() must not kill the heartbeat thread.
+
+        Without per-beat exception handling, a sustained outage or any
+        exhausted-retry path in client.heartbeat would silently kill the
+        thread while the main loop kept claiming tasks --- letting the API
+        expire the service registration and orphan the claimed tasks.
+        """
+        caplog.set_level(logging.INFO, logger=service.logger.name)
+
+        beats: list[bool] = []
+
+        def flaky_beat():
+            beats.append(True)
+            if len(beats) == 1:
+                raise RuntimeError("simulated transient heartbeat failure")
+
+        monkeypatch.setattr(service, "beat", flaky_beat)
+
+        heartbeat_thread = threading.Thread(target=service.heartbeat, daemon=True)
+        heartbeat_thread.start()
+
+        try:
+            # heartbeat_interval=1 from the ``service`` fixture, so this wait
+            # comfortably covers 3 beats: the first raises, the next two succeed
+            time.sleep(3.5)
+
+            assert heartbeat_thread.is_alive(), (
+                "heartbeat thread died after the first failed beat; "
+                "beat exception was not swallowed"
+            )
+            assert len(beats) >= 2, (
+                f"only {len(beats)} beat(s) attempted; thread did not resume "
+                "after the failure"
+            )
+            assert "Heartbeat failed" in caplog.text
+        finally:
+            service.stop()
+            heartbeat_thread.join(timeout=5)
+
     def test_claim_tasks(self, n4js_preloaded, service):
 
         service._register()

--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -227,9 +227,6 @@ class TestSynchronousComputeService:
         results = n4js.execute_query(q)
         assert results.records
 
-    @pytest.mark.skip(
-        reason="bisect: temporarily skipped to isolate CI hang on 3.11/3.13 (PR #503)"
-    )
     def test_start_interruptible_sleep(
         self, n4js_preloaded, compute_client, tmpdir, caplog
     ):

--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -227,8 +227,8 @@ class TestSynchronousComputeService:
         results = n4js.execute_query(q)
         assert results.records
 
-    def test_start_interruptible_sleep(
-        self, n4js_preloaded, compute_client, tmpdir, caplog
+    def test_service_interruptible_sleep(
+        self, n4js_preloaded, compute_client, tmpdir, caplog, monkeypatch
     ):
         n4js: Neo4jStore = n4js_preloaded
 
@@ -252,7 +252,7 @@ class TestSynchronousComputeService:
 
         # force the "no tasks claimed; sleeping" branch every cycle so the
         # service parks itself in an interruptible sleep rather than executing
-        service.claim_tasks = lambda count=1: [None]
+        monkeypatch.setattr(service, "claim_tasks", lambda count=1: [None])
 
         caplog.set_level(logging.INFO, logger=service.logger.name)
 

--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -227,6 +227,9 @@ class TestSynchronousComputeService:
         results = n4js.execute_query(q)
         assert results.records
 
+    @pytest.mark.skip(
+        reason="bisect: temporarily skipped to isolate CI hang on 3.11/3.13 (PR #503)"
+    )
     def test_start_interruptible_sleep(
         self, n4js_preloaded, compute_client, tmpdir, caplog
     ):

--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -315,3 +315,64 @@ class TestSynchronousComputeService:
             match="Could not find ComputeManagerRegistration",
         ):
             service._register()
+
+    def test_start_non_stop_exit_stops_heartbeat_thread(
+        self, compute_client, tmpdir, monkeypatch
+    ):
+        """start() should stop its heartbeat thread even when it exits without stop().
+
+        This reproduces the max_tasks/max_time-style exit path: the main loop raises
+        KeyboardInterrupt, start() catches it and returns, but service.stop() was
+        never called by the test.
+        """
+        heartbeat_started = threading.Event()
+        deregistered = threading.Event()
+
+        with tmpdir.as_cwd():
+            service = SynchronousComputeService(
+                ComputeServiceSettings(
+                    api_url=compute_client.api_url,
+                    identifier=compute_client.identifier,
+                    key=compute_client.key,
+                    name="test_compute_service_heartbeat_lifecycle",
+                    shared_basedir=Path("shared").absolute(),
+                    scratch_basedir=Path("scratch").absolute(),
+                    heartbeat_interval=300,
+                    sleep_interval=300,
+                    deep_sleep_interval=300,
+                )
+            )
+
+        monkeypatch.setattr(service, "_register", lambda: None)
+        monkeypatch.setattr(service, "_deregister", lambda: deregistered.set())
+
+        # Ensure the heartbeat thread has really started and is about to park in
+        # service.int_sleep(heartbeat_interval).
+        monkeypatch.setattr(service, "beat", lambda: heartbeat_started.set())
+
+        def raise_keyboard_interrupt_after_heartbeat(*args, **kwargs):
+            assert heartbeat_started.wait(timeout=5), "heartbeat thread never started"
+            raise KeyboardInterrupt
+
+        # Simulate the same non-stop exit class as _check_max_tasks/_check_max_time.
+        monkeypatch.setattr(service, "cycle", raise_keyboard_interrupt_after_heartbeat)
+
+        service_thread = threading.Thread(target=service.start, daemon=True)
+        service_thread.start()
+
+        try:
+            service_thread.join(timeout=5)
+
+            assert not service_thread.is_alive()
+            assert deregistered.is_set()
+
+            # This is the assertion that should fail on the current code:
+            # start() returned, but the heartbeat thread is still alive because
+            # nobody called service.stop() / int_sleep.interrupt().
+            service.heartbeat_thread.join(timeout=1)
+            assert not service.heartbeat_thread.is_alive()
+        finally:
+            # Prevent the failing test from leaking a daemon heartbeat thread.
+            service.stop()
+            if hasattr(service, "heartbeat_thread"):
+                service.heartbeat_thread.join(timeout=5)

--- a/alchemiscale/tests/integration/strategist/test_strategist_service.py
+++ b/alchemiscale/tests/integration/strategist/test_strategist_service.py
@@ -385,9 +385,6 @@ class TestStrategistService:
         strategist_service.stop()
         assert strategist_service._stop is True
 
-    @pytest.mark.skip(
-        reason="bisect: temporarily skipped to isolate CI hang on 3.11/3.13 (PR #503)"
-    )
     def test_service_interruptible_sleep(self, strategist_service, caplog):
         """stop() should interrupt the inter-cycle sleep promptly."""
         caplog.set_level(logging.DEBUG, logger="AlchemiscaleStrategistService")

--- a/alchemiscale/tests/integration/strategist/test_strategist_service.py
+++ b/alchemiscale/tests/integration/strategist/test_strategist_service.py
@@ -385,6 +385,9 @@ class TestStrategistService:
         strategist_service.stop()
         assert strategist_service._stop is True
 
+    @pytest.mark.skip(
+        reason="bisect: temporarily skipped to isolate CI hang on 3.11/3.13 (PR #503)"
+    )
     def test_service_interruptible_sleep(self, strategist_service, caplog):
         """stop() should interrupt the inter-cycle sleep promptly."""
         caplog.set_level(logging.DEBUG, logger="AlchemiscaleStrategistService")

--- a/alchemiscale/tests/integration/strategist/test_strategist_service.py
+++ b/alchemiscale/tests/integration/strategist/test_strategist_service.py
@@ -1,5 +1,6 @@
 """Integration tests for StrategistService."""
 
+import logging
 import pytest
 import threading
 import time
@@ -383,3 +384,34 @@ class TestStrategistService:
 
         strategist_service.stop()
         assert strategist_service._stop is True
+
+    def test_service_interruptible_sleep(self, strategist_service, caplog):
+        """stop() should interrupt the inter-cycle sleep promptly."""
+        caplog.set_level(logging.DEBUG, logger="AlchemiscaleStrategistService")
+
+        # a long sleep interval; if the sleep were *not* interruptible, stop()
+        # would not take effect until it elapsed and this test would time out
+        # joining the thread. With no strategies actioned, the first cycle
+        # returns immediately and the service parks in the interruptible sleep.
+        strategist_service.sleep_interval = 300
+
+        thread = threading.Thread(target=strategist_service.start)
+        thread.start()
+
+        try:
+            # wait until the service has entered its (interruptible) sleep
+            deadline = time.monotonic() + 30
+            while "Sleeping for" not in caplog.text:
+                assert time.monotonic() < deadline, "service never reached its sleep"
+                time.sleep(0.05)
+
+            interrupt_time = time.monotonic()
+            strategist_service.stop()
+            thread.join(timeout=30)
+
+            assert not thread.is_alive()
+            assert (time.monotonic() - interrupt_time) < 30
+            assert "Sleep interrupted; stopping Strategist service" in caplog.text
+        finally:
+            strategist_service.stop()
+            thread.join(timeout=30)

--- a/alchemiscale/tests/unit/compute/test_signals.py
+++ b/alchemiscale/tests/unit/compute/test_signals.py
@@ -1,0 +1,78 @@
+import signal
+
+import pytest
+
+from alchemiscale.compute.signals import (
+    DEFAULT_STOP_SIGNALS,
+    install_stop_handlers,
+)
+
+
+class StopRecorder:
+    """Minimal stoppable that records how many times ``stop()`` was called."""
+
+    def __init__(self):
+        self.stop_count = 0
+
+    def stop(self):
+        self.stop_count += 1
+
+
+@pytest.fixture
+def available_signals():
+    return [name for name in DEFAULT_STOP_SIGNALS if hasattr(signal, name)]
+
+
+@pytest.fixture
+def restore_handlers(available_signals):
+    """Save and restore process signal handlers around a test."""
+    originals = {
+        name: signal.getsignal(getattr(signal, name)) for name in available_signals
+    }
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            signal.signal(getattr(signal, name), original)
+
+
+def test_install_stop_handlers_registers_each_signal(
+    available_signals, restore_handlers
+):
+    recorder = StopRecorder()
+
+    install_stop_handlers(recorder)
+
+    for name in available_signals:
+        handler = signal.getsignal(getattr(signal, name))
+        assert callable(handler)
+
+
+def test_handler_calls_stop_and_raises_keyboard_interrupt(
+    available_signals, restore_handlers
+):
+    recorder = StopRecorder()
+
+    install_stop_handlers(recorder)
+
+    # invoke each registered handler directly (rather than actually raising the
+    # signal, which would interfere with the test process)
+    for name in available_signals:
+        handler = signal.getsignal(getattr(signal, name))
+        with pytest.raises(KeyboardInterrupt):
+            handler(getattr(signal, name), None)
+
+    # stop() should have been called exactly once per handled signal
+    assert recorder.stop_count == len(available_signals)
+
+
+def test_install_stop_handlers_skips_unknown_signals(restore_handlers):
+    recorder = StopRecorder()
+
+    # a bogus signal name must not raise; it is simply skipped
+    install_stop_handlers(recorder, signal_names=("SIGINT", "NOT_A_REAL_SIGNAL"))
+
+    handler = signal.getsignal(signal.SIGINT)
+    with pytest.raises(KeyboardInterrupt):
+        handler(signal.SIGINT, None)
+    assert recorder.stop_count == 1

--- a/alchemiscale/tests/unit/compute/test_signals.py
+++ b/alchemiscale/tests/unit/compute/test_signals.py
@@ -76,3 +76,19 @@ def test_install_stop_handlers_skips_unknown_signals(restore_handlers):
     with pytest.raises(KeyboardInterrupt):
         handler(signal.SIGINT, None)
     assert recorder.stop_count == 1
+
+
+def test_handler_without_keyboard_interrupt_calls_stop_only(
+    available_signals, restore_handlers
+):
+    recorder = StopRecorder()
+
+    install_stop_handlers(recorder, raise_keyboard_interrupt=False)
+
+    # invoking each handler should call stop() but NOT raise KeyboardInterrupt
+    for name in available_signals:
+        handler = signal.getsignal(getattr(signal, name))
+        # no pytest.raises: handler must return normally
+        handler(getattr(signal, name), None)
+
+    assert recorder.stop_count == len(available_signals)

--- a/news/issue-503.rst
+++ b/news/issue-503.rst
@@ -1,10 +1,11 @@
 **Added:**
 
-* <news item>
+* New :mod:`alchemiscale.sleep` module providing the ``InterruptableSleep`` primitive (and ``SleepInterrupted`` exception), shared by the compute service, compute manager, and strategist service.
+* ``alchemiscale.compute.signals.install_stop_handlers`` helper for wiring ``SIGHUP``/``SIGINT``/``SIGTERM`` to a service's ``stop()`` from an entry point.
 
 **Changed:**
 
-* <news item>
+* ``InterruptableSleep`` and ``SleepInterrupted`` now live in :mod:`alchemiscale.sleep`; they remain importable from :mod:`alchemiscale.compute.service` for backwards compatibility.
 
 **Deprecated:**
 
@@ -16,7 +17,7 @@
 
 **Fixed:**
 
-* ``ComputeManager`` and ``SynchronousComputeService`` now use an interruptible sleep between cycles, so ``stop()`` (and SIGINT) takes effect immediately instead of waiting for the full sleep interval to elapse.
+* ``ComputeManager``, ``SynchronousComputeService``, and ``StrategistService`` now use an interruptible sleep between cycles, so ``stop()`` (and termination signals) takes effect promptly instead of waiting for the full sleep interval to elapse. ``SynchronousComputeService`` previously constructed an ``InterruptableSleep`` but never used it for sleeping, leaving termination unresponsive during a sleep.
 
 **Security:**
 

--- a/news/issue-503.rst
+++ b/news/issue-503.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed the unused ``sched.scheduler`` instances from ``SynchronousComputeService`` and ``AsynchronousComputeService``.
+
+**Fixed:**
+
+* ``ComputeManager`` and ``SynchronousComputeService`` now use an interruptible sleep between cycles, so ``stop()`` (and SIGINT) takes effect immediately instead of waiting for the full sleep interval to elapse.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
## Summary

Makes the long-running services — `SynchronousComputeService`, `ComputeManager`, and `StrategistService` — shut down **promptly and cleanly** when asked to stop, instead of ignoring `stop()` (and termination signals) until the current sleep interval elapses. Along the way it fixes a latent dead mechanism, removes dead code, and consolidates the sleep primitive into one shared home.

## Motivation

All three services run a `while`-loop that sleeps between work cycles. They relied on a plain, **uninterruptible** `time.sleep()`, so a `stop()` (e.g. from a SIGTERM/SIGINT handler) was not noticed until the sleep finished on its own — up to `deep_sleep_interval` (300s) for the compute service, `sleep_interval` (default 1800s) for the manager. For services that hold a registration in the state store, a slow or skipped shutdown means an **orphaned `ComputeManagerRegistration`/`ComputeServiceRegistration`**.

## Changes

**Interruptible sleep across all three services**
- `ComputeManager` now sleeps via the `InterruptableSleep` functor, woken by `stop()`.
- `SynchronousComputeService` *constructed* an `InterruptableSleep` and interrupted it in `stop()`, but every actual sleep used plain `time.sleep()` — the functor was never called and the `except SleepInterrupted` handler was dead code. Its cycle sleeps now go through it.
- `StrategistService` sleeps between cycles via the functor too. **No `KeyboardInterrupt` is raised** for it: its cooperative `_stop` checks and `ProcessPoolExecutor` teardown are preserved, since raising asynchronously into the pool-managing thread risks orphaning child processes.
- Each `start()` clears the sleep event so a stopped service can be cleanly restarted.

**Shared primitive**
- Moved `InterruptableSleep`/`SleepInterrupted` into a new dependency-free `alchemiscale.sleep` module (a third consumer in a different subpackage made the previous home in `compute.service` an awkward coupling). Re-exported from `alchemiscale.compute.service` for backwards compatibility.

**Signal-handling helper**
- Added `alchemiscale.compute.signals.install_stop_handlers`, a small reusable helper that wires `SIGHUP`/`SIGINT`/`SIGTERM` to a service's `stop()`. Signal disposition is process-global and main-thread-only, so it stays at the entry point — the helper just removes the per-CLI boilerplate (and the risk of forgetting it). The compute service `synchronous` CLI command now uses it.

**Cleanup**
- Removed the unused `sched.scheduler` instances from `SynchronousComputeService`/`AsynchronousComputeService` and the now-unused `import sched`; corrected the `InterruptableSleep` docstring, which described a scheduler integration that was never wired up.

**Tests**
- Added tests asserting `stop()` promptly wakes a sleeping manager, compute service, and strategist, plus unit tests for `install_stop_handlers`.

## Companion PRs (separate repos)

The autoscaling **manager CLIs** in `alchemiscale-hpc` (SLURM) and `alchemiscale-k8s` install no signal handlers today, so SIGTERM — the signal `systemd`/`docker stop`/`scancel`/Kubernetes actually send — bypasses the `finally` block and orphans the manager registration. Those CLIs will be wired to `install_stop_handlers` in follow-up PRs to their respective repos (they consume the helper added here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)