### PR TITLE
Consolidate compute service init and start settings

### DIFF
--- a/alchemiscale/cli.py
+++ b/alchemiscale/cli.py
@@ -385,16 +385,13 @@ def synchronous(config_file, name, compute_manager_id):
 
     params = yaml.safe_load(config_file)
 
-    params_init = params.get("init", {})
-    params_start = params.get("start", {})
-
     if name is not None:
-        params_init["name"] = name
+        params["name"] = name
 
     if compute_manager_id is not None:
-        params_init["compute_manager_id"] = compute_manager_id
+        params["compute_manager_id"] = compute_manager_id
 
-    service = SynchronousComputeService(ComputeServiceSettings(**params_init))
+    service = SynchronousComputeService(ComputeServiceSettings(**params))
 
     # add signal handling
     for signame in {"SIGHUP", "SIGINT", "SIGTERM"}:
@@ -406,7 +403,7 @@ def synchronous(config_file, name, compute_manager_id):
         signal.signal(getattr(signal, signame), stop)
 
     try:
-        service.start(**params_start)
+        service.start()
     except KeyboardInterrupt:
         pass
 

--- a/alchemiscale/compute/service.py
+++ b/alchemiscale/compute/service.py
@@ -78,6 +78,8 @@ class SynchronousComputeService:
         self.deep_sleep_interval = self.settings.deep_sleep_interval
         self.heartbeat_interval = self.settings.heartbeat_interval
         self.claim_limit = self.settings.claim_limit
+        self.max_tasks = self.settings.max_tasks
+        self.max_time = self.settings.max_time
 
         self.client = AlchemiscaleComputeClient(
             api_url=self.settings.api_url,
@@ -336,23 +338,19 @@ class SynchronousComputeService:
         self._check_max_tasks(max_tasks)
         self._check_max_time(max_time)
 
-    def start(self, max_tasks: int | None = None, max_time: int | None = None):
+    def start(self):
         """Start the service.
 
-        Limits to the maximum number of executed tasks or seconds to run for
-        can be set. The first maximum to be hit will trigger the service to
-        exit.
-
-        Parameters
-        ----------
-        max_tasks
-            Max number of Tasks to execute before exiting.
-            If `None`, the service will have no task limit.
-        max_time
-            Max number of seconds to run before exiting.
-            If `None`, the service will have no time limit.
+        The service runs until it is told to stop, or until one of the limits
+        configured on its settings is reached. ``max_tasks`` caps the number of
+        Tasks executed and ``max_time`` caps the number of seconds run; the
+        first maximum to be hit triggers the service to exit. Either limit being
+        ``None`` (the default) means no limit of that kind.
 
         """
+        max_tasks = self.max_tasks
+        max_time = self.max_time
+
         self._stop = False
 
         # add ComputeServiceRegistration

--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -73,6 +73,20 @@ class ComputeServiceSettings(BaseModel):
     claim_limit: int = Field(
         1, description="Maximum number of Tasks to claim at a time from a TaskHub."
     )
+    max_tasks: int | None = Field(
+        None,
+        description=(
+            "Maximum number of Tasks to execute before the service shuts down. "
+            "If `None`, the service has no task limit."
+        ),
+    )
+    max_time: int | None = Field(
+        None,
+        description=(
+            "Maximum number of seconds to run before the service shuts down. "
+            "If `None`, the service has no time limit."
+        ),
+    )
     loglevel: str = Field(
         "WARN",
         description="The loglevel at which to report; see the :mod:`logging` docs for available levels.",

--- a/alchemiscale/tests/integration/compute/client/test_compute_manager.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_manager.py
@@ -34,14 +34,14 @@ class LocalTestingComputeManager(ComputeManager):
         if exception := LocalTestingComputeManager.exception:
             raise exception
 
-        params_start = {
-            "max_time": self.service_max_time or 10,
-            "max_tasks": self.service_max_tasks or 2,
-        }
+        # service lifetime limits now live on the ComputeServiceSettings the
+        # manager hands to each service, rather than being passed to start()
+        self.service_settings.max_time = self.service_max_time or 10
+        self.service_settings.max_tasks = self.service_max_tasks or 2
 
         proc = Process(
             target=LocalTestingComputeManager._create_compute_service,
-            args=(self.service_settings, params_start),
+            args=(self.service_settings,),
         )
         proc.start()
         LocalTestingComputeManager.service_processes.append(proc)
@@ -49,7 +49,7 @@ class LocalTestingComputeManager(ComputeManager):
         return 1
 
     @staticmethod
-    def _create_compute_service(service_settings, params_start):
+    def _create_compute_service(service_settings):
 
         from alchemiscale.compute.service import SynchronousComputeService
 
@@ -65,7 +65,7 @@ class LocalTestingComputeManager(ComputeManager):
             signal.signal(getattr(signal, signame), stop)
 
         try:
-            service.start(**params_start)
+            service.start()
         except KeyboardInterrupt:
             pass
 

--- a/alchemiscale/tests/integration/test_cli.py
+++ b/alchemiscale/tests/integration/test_cli.py
@@ -154,16 +154,14 @@ def compute_service_config(compute_api_args):
     host, port, _ = compute_api_args
 
     config = {
-        "init": {
-            "api_url": f"http://{host}:{port}",
-            "identifier": "test-compute-user",
-            "key": "test-comute-user-key",
-            "name": "test-compute-service",
-            "shared_basedir": "./shared",
-            "scratch_basedir": "./scratch",
-            "loglevel": "INFO",
-        },
-        "start": {"max_time": None},
+        "api_url": f"http://{host}:{port}",
+        "identifier": "test-compute-user",
+        "key": "test-comute-user-key",
+        "name": "test-compute-service",
+        "shared_basedir": "./shared",
+        "scratch_basedir": "./scratch",
+        "loglevel": "INFO",
+        "max_time": None,
     }
 
     return config
@@ -190,8 +188,8 @@ def test_compute_synchronous(
 
     # create compute identity; add all scope access
     identity = CredentialedComputeIdentity(
-        identifier=compute_service_config["init"]["identifier"],
-        hashed_key=hash_key(compute_service_config["init"]["key"]),
+        identifier=compute_service_config["identifier"],
+        hashed_key=hash_key(compute_service_config["key"]),
     )
 
     n4js.create_credentialed_entity(identity)
@@ -216,7 +214,7 @@ def test_compute_synchronous(
 
             q = f"""
             match (csreg:ComputeServiceRegistration)
-            where csreg.identifier =~ "{compute_service_config['init']['name']}.*"
+            where csreg.identifier =~ "{compute_service_config['name']}.*"
             return csreg
             """
             while True:

--- a/devtools/configs/synchronous-compute-settings.yaml
+++ b/devtools/configs/synchronous-compute-settings.yaml
@@ -1,99 +1,93 @@
 ---
-# options for service initialization
-init:
+# URL of the compute API to execute Tasks for.
+api_url: https://compute.alchemiscale-instance.localdomain
 
-  # URL of the compute API to execute Tasks for.
-  api_url: https://compute.alchemiscale-instance.localdomain
+# Identifier for the compute identity used for authentication.
+identifier: compute-identity
 
-  # Identifier for the compute identity used for authentication.
-  identifier: compute-identity
+# Credential for the compute identity used for authentication.
+key: "compute-identity-key"
 
-  # Credential for the compute identity used for authentication.
-  key: "compute-identity-key"
+# The name to give this compute service; used for Task provenance, so
+# typically set to a distinct value to distinguish different compute
+# resources, e.g. different hosts or HPC clusters.
+name: compute-resource-name
 
-  # The name to give this compute service; used for Task provenance, so
-  # typically set to a distinct value to distinguish different compute
-  # resources, e.g. different hosts or HPC clusters.
-  name: compute-resource-name
-  
-  # Filesystem path to use for `ProtocolDAG` `shared` space.
-  shared_basedir: "./shared"
+# Filesystem path to use for `ProtocolDAG` `shared` space.
+shared_basedir: "./shared"
 
-  # Filesystem path to use for `ProtocolUnit` `scratch` space.
-  scratch_basedir: "./scratch"
+# Filesystem path to use for `ProtocolUnit` `scratch` space.
+scratch_basedir: "./scratch"
 
-  # If True, don't remove shared directories for `ProtocolDAG`s after
-  # completion.
-  keep_shared: False
+# If True, don't remove shared directories for `ProtocolDAG`s after
+# completion.
+keep_shared: False
 
-  # If True, don't remove scratch directories for `ProtocolUnit`s after
-  # completion.
-  keep_scratch: False
+# If True, don't remove scratch directories for `ProtocolUnit`s after
+# completion.
+keep_scratch: False
 
-  # Number of times to attempt a given Task on failure
-  n_retries: 3
+# Number of times to attempt a given Task on failure
+n_retries: 3
 
-  # Time in seconds to sleep if no Tasks claimed from compute API.
-  sleep_interval: 30
+# Time in seconds to sleep if no Tasks claimed from compute API.
+sleep_interval: 30
 
-  # Frequency at which to send heartbeats to compute API.
-  heartbeat_interval: 300
+# Frequency at which to send heartbeats to compute API.
+heartbeat_interval: 300
 
-  # Scopes to limit Task claiming to; defaults to all Scopes accessible by
-  # compute identity.
-  scopes:
-    - '*-*-*'
+# Scopes to limit Task claiming to; defaults to all Scopes accessible by
+# compute identity.
+scopes:
+  - '*-*-*'
 
-  # Names of Protocols to run with this service; `None` means no restriction
-  protocols: null
+# Names of Protocols to run with this service; `None` means no restriction
+protocols: null
 
-  # Maximum number of Tasks to claim at a time from a TaskHub.
-  claim_limit: 1
+# Maximum number of Tasks to claim at a time from a TaskHub.
+claim_limit: 1
 
-  # The loglevel at which to report via STDOUT; see the :mod:`logging` docs for
-  # available levels.
-  loglevel: 'WARN'
+# Maximum number of Tasks to execute before exiting. If `null`, the service
+# will have no task limit.
+max_tasks: null
 
-  # Path to file for logging output; if not set, logging will only go to
-  # STDOUT.
-  logfile: null
+# Maximum number of seconds to run before exiting. If `null`, the service will
+# have no time limit.
+max_time: null
 
-  # Location of the cache directory as either a `pathlib.Path` or `str`.
-  # If ``None`` is provided then the directory will be determined via
-  # the ``XDG_CACHE_HOME`` environment variable or default to
-  # ``${HOME}/.cache/alchemiscale``. Default ``None``.
-  client_cache_directory: null
+# The loglevel at which to report via STDOUT; see the :mod:`logging` docs for
+# available levels.
+loglevel: 'WARN'
 
-  # Maximum size of the client cache in bytes. Default 1 GiB.
-  client_cache_size_limit: 1073741824
+# Path to file for logging output; if not set, logging will only go to
+# STDOUT.
+logfile: null
 
-  # Whether or not to use the local cache on disk.
-  client_use_local_cache: false
+# Location of the cache directory as either a `pathlib.Path` or `str`.
+# If ``None`` is provided then the directory will be determined via
+# the ``XDG_CACHE_HOME`` environment variable or default to
+# ``${HOME}/.cache/alchemiscale``. Default ``None``.
+client_cache_directory: null
 
-  # Maximum number of times to retry a request. In the case the API service is
-  # unresponsive an expoenential backoff is applied with retries until this
-  # number is reached. If set to -1, retries will continue indefinitely until
-  # success.
-  client_max_retries: 5
+# Maximum size of the client cache in bytes. Default 1 GiB.
+client_cache_size_limit: 1073741824
 
-  # The base number of seconds to use for exponential backoff. Must be greater
-  # than 1.0. 
-  client_retry_base_seconds: 2.0
- 
-  # Maximum number of seconds to sleep between retries; avoids runaway
-  # exponential backoff while allowing for many retries.
-  client_retry_max_seconds: 60.0
+# Whether or not to use the local cache on disk.
+client_use_local_cache: false
 
-  # Whether to verify SSL certificate presented by the API server.
-  client_verify: true
+# Maximum number of times to retry a request. In the case the API service is
+# unresponsive an expoenential backoff is applied with retries until this
+# number is reached. If set to -1, retries will continue indefinitely until
+# success.
+client_max_retries: 5
 
-# options for service execution
-start:
+# The base number of seconds to use for exponential backoff. Must be greater
+# than 1.0.
+client_retry_base_seconds: 2.0
 
-  # Max number of Tasks to execute before exiting. If `null`, the service will
-  # have no task limit.
-  max_tasks: null
+# Maximum number of seconds to sleep between retries; avoids runaway
+# exponential backoff while allowing for many retries.
+client_retry_max_seconds: 60.0
 
-  # Max number of seconds to run before exiting. If `null`, the service will
-  # have no time limit.
-  max_time: null
+# Whether to verify SSL certificate presented by the API server.
+client_verify: true

--- a/docs/compute.rst
+++ b/docs/compute.rst
@@ -102,29 +102,23 @@ The ``envsubst`` line in particular will make a config specific to this job, wit
 A subset of options used in the config file are given below::
 
     ---
-    # options for service initialization
-    init:
-    
-      # Filesystem path to use for `ProtocolDAG` `shared` space.
-      shared_basedir: "/scratch/${USER}/${JOBID}-${JOBINDEX}/shared"
-    
-      # Filesystem path to use for `ProtocolUnit` `scratch` space.
-      scratch_basedir: "/scratch/${USER}/${JOBID}-${JOBINDEX}/scratch"
-    
-      # Path to file for logging output; if not set, logging will only go to
-      # STDOUT.
-      logfile: /home/${USER}/logs/service.${JOBID}.log
-    
-    # options for service execution
-    start:
-    
-      # Max number of Tasks to execute before exiting. If `null`, the service will
-      # have no task limit.
-      max_tasks: 1
-    
-      # Max number of seconds to run before exiting. If `null`, the service will
-      # have no time limit.
-      max_time: 300
+    # Filesystem path to use for `ProtocolDAG` `shared` space.
+    shared_basedir: "/scratch/${USER}/${JOBID}-${JOBINDEX}/shared"
+
+    # Filesystem path to use for `ProtocolUnit` `scratch` space.
+    scratch_basedir: "/scratch/${USER}/${JOBID}-${JOBINDEX}/scratch"
+
+    # Path to file for logging output; if not set, logging will only go to
+    # STDOUT.
+    logfile: /home/${USER}/logs/service.${JOBID}.log
+
+    # Max number of Tasks to execute before exiting. If `null`, the service will
+    # have no task limit.
+    max_tasks: 1
+
+    # Max number of seconds to run before exiting. If `null`, the service will
+    # have no time limit.
+    max_time: 300
 
 
 For HPC job-based execution, we recommend limiting the number of :py:class:`~alchemiscale.storage.models.Task`\s the compute service executes to a small number, preferrably 1, and setting a time limit beyond which the compute service will shut down.

--- a/news/issue-504.rst
+++ b/news/issue-504.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* ``ComputeServiceSettings`` gained ``max_tasks`` and ``max_time`` fields (both ``int | None``, default ``None`` = no limit), folding service lifetime limits into the single settings object.
+
+**Changed:**
+
+* ``SynchronousComputeService.start()`` no longer takes ``max_tasks`` or ``max_time`` parameters; both are read from the service's settings.
+* The ``alchemiscale compute synchronous`` CLI now loads a flat YAML config — all fields live at the top level rather than under ``init:`` / ``start:`` keys.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* The ``init:`` / ``start:`` nested YAML wrapper for compute service configs. Legacy nested configs now fail validation with a clear error (hard cutover).
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
## Summary

Folds `max_tasks` and `max_time` into `ComputeServiceSettings` so a compute service is fully described by a single settings object. `SynchronousComputeService.start()` no longer takes parameters — it reads its lifetime limits from settings.

## Motivation

The previous split (intensive `init` settings vs extensive `start` settings) created unnecessary complexity for compute managers, which had to represent the service's complete configuration across two objects. With one object, a manager can hand a service its full config — exactly what `ComputeManager` already does in everything but these two fields.

## Configuration format

The `init:` / `start:` YAML wrapper is gone; all fields live at the top level. **Hard cutover** — legacy nested configs now fail validation with a clear error.

```yaml
# before
init:
  api_url: ...
  claim_limit: 1
start:
  max_tasks: 1
  max_time: 300

# after
api_url: ...
claim_limit: 1
max_tasks: 1
max_time: 300
```

## Changes

- `ComputeServiceSettings`: add `max_tasks`, `max_time` fields (both `int | None`, default `None` = no limit).
- `SynchronousComputeService`: `start()` reduced to `(self)`; reads limits from settings (cached in `__init__`).
- `alchemiscale compute synchronous` CLI: loads flat config.
- Devtools config + docs example flattened.
- Affected integration tests updated.

## Downstream

This is the load-bearing change. Companion PRs follow in `alchemiscale-hpc`, `alchemiscale-k8s`, and `alchemiscale-fah`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)