### PR TITLE
Add nest-asyncio to test environment

### DIFF
--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -12,6 +12,7 @@ dependencies:
   - pydantic >2
   - pydantic-settings
   - async-lru
+  - nest-asyncio
   - diskcache
   - libsqlite<3.49  # newer versions cause diskcache to fail
   - zstandard


### PR DESCRIPTION
## Problem

Nearly all client integration tests are failing on `main` (and every open PR) with:

```
ModuleNotFoundError: No module named 'nest_asyncio'
  alchemiscale/base/client.py:278
```

`BaseClient._run_async` imports `nest_asyncio` (added in #487), but it was never declared in `devtools/conda-envs/test.yml`. It was satisfied transitively until a recent dependency resolution dropped that path, exposing the missing declaration. CI was green as recently as 2026-06-02 and went red on 2026-06-04.

## Fix

Declare `nest-asyncio` explicitly in `test.yml`, next to `async-lru` (the dependency it exists to support). It is already present in `alchemiscale-client.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)