### PR TITLE
Bump gufe / openfe / feflow runtime env pins to current latest stable

### DIFF
--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -8,8 +8,8 @@ dependencies:
   - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe=1.6.1
-  - openfe=1.6.1
+  - gufe=1.10.0
+  - openfe=1.11.1
   - requests
   - click
   - httpx
@@ -26,7 +26,7 @@ dependencies:
   - nest-asyncio
 
   # openmm protocols
-  - feflow=0.1.4
+  - feflow=0.2.1
 
   # additional pins
   - openmm=8.2.0

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -8,8 +8,8 @@ dependencies:
   - cuda-version >=12
   
   # alchemiscale dependencies
-  - gufe=1.6.1
-  - openfe=1.6.1
+  - gufe=1.10.0
+  - openfe=1.11.1
   - requests
   - click
   - httpx
@@ -22,7 +22,7 @@ dependencies:
   - stratocaster
 
   # openmm protocols
-  - feflow=0.1.4
+  - feflow=0.2.1
 
   # additional pins
   - openmm=8.2.0

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -8,8 +8,8 @@ dependencies:
   - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe=1.6.1
-  - openfe=1.6.1
+  - gufe=1.10.0
+  - openfe=1.11.1
   - requests
   - click
   - pydantic >2
@@ -39,7 +39,7 @@ dependencies:
   - cryptography
 
   # openmm protocols
-  - feflow=0.1.4
+  - feflow=0.2.1
 
   # additional pins
   - openmm=8.2.0

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -7,8 +7,8 @@ dependencies:
   - cuda-version >=12
 
   # alchemiscale dependencies
-  - gufe =1.7.1
-  - openfe =1.8.0
+  - gufe =1.10.0
+  - openfe =1.11.1
   - pydantic >2
   - pydantic-settings
   - async-lru
@@ -41,7 +41,7 @@ dependencies:
   - cryptography
 
   # openmm protocols
-  - feflow>=0.1.4
+  - feflow =0.2.1
 
   ## cli
   - click


### PR DESCRIPTION
## Summary

Extracted from #507 to unblock other inflight PRs that need the newer dependency set without waiting for the larger feature work.

``feflow`` 0.2.1 hit conda-forge and now pins ``gufe >=1.9.0,<2`` and ``openfe >=1.10.0,<2``. The existing pins (``gufe=1.6.1`` / ``openfe=1.6.1`` / ``feflow=0.1.4`` in the deployment envs, ``gufe=1.7.1`` / ``openfe=1.8.0`` in test) leave callers unable to use ``feflow`` 0.2.1 against an ``alchemiscale`` env.

This PR bumps the trio to the latest mutually-compatible exact pins across the four runtime env files:

| File | Before | After |
|---|---|---|
| ``devtools/conda-envs/test.yml`` | ``gufe=1.7.1``, ``openfe=1.8.0``, ``feflow>=0.1.4`` | ``gufe=1.10.0``, ``openfe=1.11.1``, ``feflow=0.2.1`` |
| ``devtools/conda-envs/alchemiscale-server.yml`` | ``gufe=1.6.1``, ``openfe=1.6.1``, ``feflow=0.1.4`` | ``gufe=1.10.0``, ``openfe=1.11.1``, ``feflow=0.2.1`` |
| ``devtools/conda-envs/alchemiscale-compute.yml`` | ``gufe=1.6.1``, ``openfe=1.6.1``, ``feflow=0.1.4`` | ``gufe=1.10.0``, ``openfe=1.11.1``, ``feflow=0.2.1`` |
| ``devtools/conda-envs/alchemiscale-client.yml`` | ``gufe=1.6.1``, ``openfe=1.6.1``, ``feflow=0.1.4`` | ``gufe=1.10.0``, ``openfe=1.11.1``, ``feflow=0.2.1`` |

### Version cascade arithmetic

- ``feflow=0.2.1`` requires ``gufe >=1.9.0,<2`` and ``openfe >=1.10.0,<2``.
- ``openfe-base=1.11.1`` requires ``gufe >=1.10.0,<1.11`` → so ``openfe=1.11.1`` forces ``gufe=1.10.0`` exactly.
- ``openfe-base=1.10.0`` requires ``gufe >=1.9.0,<1.10`` (the other arm of the cascade).
- The 1.11.1 / 1.10.0 pair was picked as the current latest stable.

### Why ``docs.yml`` is intentionally unchanged

The docs build runs sphinx 9's autodoc, which imports ``gufe.settings.models`` and trips on:

```python
ph: PositiveFloat | None = Field(None, description="Simulation pH.")
    ~~~~~~~~~~~~~~^~~~~~
TypeError: unsupported operand type(s) for |: 'PositiveFloat' and 'NoneType'
```

This works fine in ``gufe`` 1.3.0 (pydantic v1, ``PositiveFloat`` is a class with ``__or__``) but breaks in ``gufe`` >=1.8.0 (pydantic v2, ``PositiveFloat`` is ``Annotated[float, ...]``, no ``__or__``). ``docs.yml`` only needs ``gufe`` for intersphinx and type-hint resolution, so leaving it at 1.3.0 keeps the docs build green; the docs env bump is a separate concern, not part of this maintenance PR.

### Validation

This trio was applied on #507 and CI confirmed green across the test matrix (3.11/3.12/3.13) and ReadTheDocs.

## Test plan

- [ ] CI ``tests`` matrix green on ubuntu / 3.11, 3.12, 3.13
- [ ] CI ``black`` green
- [ ] ``docs/readthedocs.org`` green (it's not changed here, so this is just confirming nothing else regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)